### PR TITLE
T-020: finalize draft  viewer constructs DeviceFields; docs/site-url …

### DIFF
--- a/aule/engine/src/fields.rs
+++ b/aule/engine/src/fields.rs
@@ -69,7 +69,12 @@ pub struct DeviceFields {
 impl DeviceFields {
     /// Create new device buffers sized for `cells` and the corresponding bind group.
     pub fn new(device: &wgpu::Device, cells: usize) -> Self {
-        fn buf(device: &wgpu::Device, size: usize, label: &str, usage: wgpu::BufferUsages) -> wgpu::Buffer {
+        fn buf(
+            device: &wgpu::Device,
+            size: usize,
+            label: &str,
+            usage: wgpu::BufferUsages,
+        ) -> wgpu::Buffer {
             device.create_buffer(&wgpu::BufferDescriptor {
                 label: Some(label),
                 size: size as u64,
@@ -79,7 +84,9 @@ impl DeviceFields {
         }
         let bytes_f32 = cells * std::mem::size_of::<f32>();
         let bytes_u32 = cells * std::mem::size_of::<u32>();
-        let usage = wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST;
+        let usage = wgpu::BufferUsages::STORAGE
+            | wgpu::BufferUsages::COPY_SRC
+            | wgpu::BufferUsages::COPY_DST;
         let h = buf(device, bytes_f32, "h", usage);
         let th_c = buf(device, bytes_f32, "th_c", usage);
         let age_ocean = buf(device, bytes_f32, "age_ocean", usage);
@@ -91,7 +98,13 @@ impl DeviceFields {
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: Some("fields-bgl"),
             entries: &[
-                Self::entry(0), Self::entry(1), Self::entry(2), Self::entry(3), Self::entry(4), Self::entry(5), Self::entry(6),
+                Self::entry(0),
+                Self::entry(1),
+                Self::entry(2),
+                Self::entry(3),
+                Self::entry(4),
+                Self::entry(5),
+                Self::entry(6),
             ],
         });
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -114,17 +127,23 @@ impl DeviceFields {
         wgpu::BindGroupLayoutEntry {
             binding,
             visibility: wgpu::ShaderStages::COMPUTE,
-            ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: false }, has_dynamic_offset: false, min_binding_size: None },
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Storage { read_only: false },
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
             count: None,
         }
     }
-    fn bg_entry<'a>(binding: u32, buffer: &'a wgpu::Buffer) -> wgpu::BindGroupEntry<'a> {
+    fn bg_entry(binding: u32, buffer: &wgpu::Buffer) -> wgpu::BindGroupEntry<'_> {
         wgpu::BindGroupEntry { binding, resource: buffer.as_entire_binding() }
     }
 
     /// Recreate all buffers and bind group if size changes.
     pub fn resize(&mut self, device: &wgpu::Device, new_cells: usize) {
-        if new_cells == self.cells { return; }
+        if new_cells == self.cells {
+            return;
+        }
         *self = Self::new(device, new_cells);
     }
 }

--- a/aule/engine/src/gpu.rs
+++ b/aule/engine/src/gpu.rs
@@ -40,5 +40,3 @@ impl GpuContext {
         Self { instance, device, queue }
     }
 }
-
-

--- a/aule/engine/src/lib.rs
+++ b/aule/engine/src/lib.rs
@@ -5,10 +5,10 @@
 
 /// Field and tiling views.
 pub mod fields;
-/// Geodesic grid module.
-pub mod grid;
 /// Minimal GPU helper for tests (T-020).
 pub mod gpu;
+/// Geodesic grid module.
+pub mod grid;
 
 /// Returns the engine version string from Cargo metadata.
 pub fn version() -> &'static str {

--- a/aule/engine/tests/fields.rs
+++ b/aule/engine/tests/fields.rs
@@ -1,9 +1,14 @@
 use engine::fields::DeviceFields;
 use engine::gpu::GpuContext;
-use std::sync::{atomic::{AtomicBool, Ordering}, Arc};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use wgpu::util::DeviceExt;
 
-fn roundtrip_sizes() -> Vec<usize> { vec![1024, 1536, 2048] }
+fn roundtrip_sizes() -> Vec<usize> {
+    vec![1024, 1536, 2048]
+}
 
 #[test]
 fn device_fields_roundtrip_and_resize() {
@@ -11,25 +16,55 @@ fn device_fields_roundtrip_and_resize() {
     for n in roundtrip_sizes() {
         let mut df = DeviceFields::new(&ctx.device, n);
         // Write patterns
-        let mut encoder = ctx.device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some("enc") });
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some("enc") });
         let h_host: Vec<f32> = (0..n).map(|i| i as f32 + 0.5).collect();
         let pid_host: Vec<u32> = (0..n as u32).collect();
         // staging for upload
         let h_staging = ctx.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("h_staging"), contents: bytemuck::cast_slice(&h_host), usage: wgpu::BufferUsages::COPY_SRC,
+            label: Some("h_staging"),
+            contents: bytemuck::cast_slice(&h_host),
+            usage: wgpu::BufferUsages::COPY_SRC,
         });
         let pid_staging = ctx.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("pid_staging"), contents: bytemuck::cast_slice(&pid_host), usage: wgpu::BufferUsages::COPY_SRC,
+            label: Some("pid_staging"),
+            contents: bytemuck::cast_slice(&pid_host),
+            usage: wgpu::BufferUsages::COPY_SRC,
         });
-        encoder.copy_buffer_to_buffer(&h_staging, 0, &df.h, 0, (n * std::mem::size_of::<f32>()) as u64);
-        encoder.copy_buffer_to_buffer(&pid_staging, 0, &df.plate_id, 0, (n * std::mem::size_of::<u32>()) as u64);
+        encoder.copy_buffer_to_buffer(
+            &h_staging,
+            0,
+            &df.h,
+            0,
+            (n * std::mem::size_of::<f32>()) as u64,
+        );
+        encoder.copy_buffer_to_buffer(
+            &pid_staging,
+            0,
+            &df.plate_id,
+            0,
+            (n * std::mem::size_of::<u32>()) as u64,
+        );
         ctx.queue.submit(Some(encoder.finish()));
         ctx.device.poll(wgpu::Maintain::Wait);
 
         // Read back
-        let mut encoder = ctx.device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some("rd") });
-        let h_read = ctx.device.create_buffer(&wgpu::BufferDescriptor { label: Some("h_read"), size: (n * 4) as u64, usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST, mapped_at_creation: false });
-        let pid_read = ctx.device.create_buffer(&wgpu::BufferDescriptor { label: Some("pid_read"), size: (n * 4) as u64, usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST, mapped_at_creation: false });
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some("rd") });
+        let h_read = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("h_read"),
+            size: (n * 4) as u64,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let pid_read = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("pid_read"),
+            size: (n * 4) as u64,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
         encoder.copy_buffer_to_buffer(&df.h, 0, &h_read, 0, (n * 4) as u64);
         encoder.copy_buffer_to_buffer(&df.plate_id, 0, &pid_read, 0, (n * 4) as u64);
         ctx.queue.submit(Some(encoder.finish()));
@@ -58,10 +93,10 @@ fn device_fields_roundtrip_and_resize() {
 fn map_wait(device: &wgpu::Device, buffer: &wgpu::Buffer) {
     let done = Arc::new(AtomicBool::new(false));
     let done_c = done.clone();
-    buffer.slice(..).map_async(wgpu::MapMode::Read, move |_| { done_c.store(true, Ordering::SeqCst); });
+    buffer.slice(..).map_async(wgpu::MapMode::Read, move |_| {
+        done_c.store(true, Ordering::SeqCst);
+    });
     while !done.load(Ordering::SeqCst) {
         device.poll(wgpu::Maintain::Wait);
     }
 }
-
-

--- a/aule/viewer/src/main.rs
+++ b/aule/viewer/src/main.rs
@@ -170,6 +170,12 @@ fn main() {
     let window: &'static Window = Box::leak(Box::new(window_init));
     let mut gpu = pollster::block_on(GpuState::new(window));
     let mut _egui_ctx = egui::Context::default();
+    // T-020: Construct device field buffers sized to the grid (then drop)
+    {
+        let f: u32 = 64;
+        let g_tmp = engine::grid::Grid::new(f);
+        let _device_fields = engine::fields::DeviceFields::new(&gpu.device, g_tmp.cells);
+    }
     log_grid_info();
 
     event_loop


### PR DESCRIPTION
Draft PR: T-020 — GPU field buffers (SoA)
Summary
Implements GPU-side SoA buffers for core fields with WGSL-safe layouts.
Provides minimal GPU context for tests.
Adds round-trip and resize tests.
Viewer constructs and drops device buffers at startup (no UI/readback).
Changes
aule/engine/src/fields.rs
Adds DeviceFields with stable bindings 0..6:
0: h (f32)
1: th_c (f32)
2: age_ocean (f32)
3: S (f32)
4: V (f32)
5: plate_id (u32)
6: B (f32)
new() creates buffers + bind group; resize() rebuilds on grow/shrink.
IDs/masks are u32 on GPU; conversions happen at upload/download call sites.
aule/engine/src/gpu.rs
GpuContext helper (Instance, Device, Queue), requests default limits (allows storage buffers in tests).
aule/engine/tests/fields.rs
Round-trip bit-identical for sizes {1024, 1536, 2048}.
Resize grow/shrink; verifies bind group rebuilds.
aule/shaders/buffers.wgsl
Declares storage buffers and an identity compute entry (for bindings validation only).
aule/viewer/src/main.rs
Constructs DeviceFields with cells = grid.cells at F=64 and drops it (no rendering).
Acceptance Criteria Matrix
Binding order stable (0..6): done; see DeviceFields::new and buffers.wgsl.
IDs/masks as u32 on GPU: done (plate_id binding 5).
Round-trip bit-identical: tests pass for sizes {1024, 1536, 2048}.
resize() grow/shrink: reconstructs buffers and bind group; test covers both paths.
Viewer can create the bind group: runs at F=64 without crash.
CI green on Windows/Linux/macOS: fmt/clippy/tests pass.
How to verify locally
Full check:
cargo fmt --all --check
cargo clippy --all-targets -- -D warnings
cargo test --all
Focused tests:
cargo test -p engine --test fields -- --nocapture
Run viewer:
cargo run -p viewer
Notes
No new runtime crates; pollster is a dev-dependency (engine tests).
Binding order and buffer types are documented in DeviceFields and mirrored in buffers.wgsl.
We request default device limits in tests to allow multiple storage buffers.
Toolchain and rustfmt pinned for CI parity; LF enforced via .gitattributes.