### PR TITLE
feat(T-060): steady-state oceanic age via Dijkstra + agedepth; HUD ov…

### DIFF
--- a/aule/engine/src/age.rs
+++ b/aule/engine/src/age.rs
@@ -1,0 +1,159 @@
+//! Steady-state oceanic age via Dijkstra from ridge seeds and age→depth mapping.
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+
+use crate::boundaries::Boundaries;
+use crate::geo;
+use crate::grid::Grid;
+
+const RADIUS_M: f64 = 6_371_000.0;
+
+/// Parameters for steady-state age solver.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AgeParams {
+    /// Minimum speed used to avoid infinite times at stagnation (m/yr).
+    pub v_floor_m_per_yr: f64,
+}
+
+impl Default for AgeParams {
+    fn default() -> Self {
+        Self { v_floor_m_per_yr: 0.005 }
+    }
+}
+
+/// Outputs of the age solver and bathymetry mapping.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AgeOutputs {
+    /// Age in Myr per cell (len = grid.cells)
+    pub age_myr: Vec<f32>,
+    /// Bathymetry in meters (positive down)
+    pub depth_m: Vec<f32>,
+    /// Min/max of age
+    pub min_max_age: (f32, f32),
+    /// Min/max of depth
+    pub min_max_depth: (f32, f32),
+}
+
+#[derive(Copy, Clone, Debug)]
+struct QueueItem {
+    t_yr: f64,
+    cell: u32,
+}
+impl Eq for QueueItem {}
+impl PartialEq for QueueItem {
+    fn eq(&self, other: &Self) -> bool {
+        self.t_yr.eq(&other.t_yr) && self.cell == other.cell
+    }
+}
+impl PartialOrd for QueueItem {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for QueueItem {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Reverse by time (min-heap behavior)
+        match self.t_yr.partial_cmp(&other.t_yr) {
+            // Reverse ordering: smaller t_yr = Greater ordering so it pops later
+            Some(Ordering::Less) => Ordering::Greater,
+            Some(Ordering::Greater) => Ordering::Less,
+            Some(Ordering::Equal) => self.cell.cmp(&other.cell).reverse(),
+            None => Ordering::Equal,
+        }
+    }
+}
+
+/// Compute steady-state age and bathymetry from ridges and velocities.
+pub fn compute_age_and_bathymetry(
+    grid: &Grid,
+    boundaries: &Boundaries,
+    plate_id: &[u16],
+    v_en: &[[f32; 2]],
+    params: AgeParams,
+) -> AgeOutputs {
+    assert_eq!(plate_id.len(), grid.cells);
+    assert_eq!(v_en.len(), grid.cells);
+
+    // Build ridge seeds from divergent edges
+    let mut is_seed = vec![false; grid.cells];
+    for &(u, v, class) in &boundaries.edges {
+        if class == 1 {
+            // divergent
+            is_seed[u as usize] = true;
+            is_seed[v as usize] = true;
+        }
+    }
+
+    // Dijkstra over cells constrained by plate id
+    let mut dist_yr: Vec<f64> = vec![f64::INFINITY; grid.cells];
+    let mut visited: Vec<bool> = vec![false; grid.cells];
+    let mut heap: BinaryHeap<QueueItem> = BinaryHeap::new();
+
+    for i in 0..grid.cells {
+        if is_seed[i] {
+            dist_yr[i] = 0.0;
+            heap.push(QueueItem { t_yr: 0.0, cell: i as u32 });
+        }
+    }
+
+    let vfloor = params.v_floor_m_per_yr.max(1e-12);
+    let mut pos_unit: Vec<[f64; 3]> = Vec::with_capacity(grid.cells);
+    for p in &grid.pos_xyz {
+        let r = [p[0] as f64, p[1] as f64, p[2] as f64];
+        pos_unit.push(geo::normalize(r));
+    }
+
+    while let Some(QueueItem { t_yr, cell }) = heap.pop() {
+        let u = cell as usize;
+        if visited[u] {
+            continue;
+        }
+        visited[u] = true;
+
+        let pid_u = plate_id[u];
+        // neighbors within same plate
+        for &vn in &grid.n1[u] {
+            let v = vn as usize;
+            if plate_id[v] != pid_u {
+                continue;
+            }
+            if visited[v] {
+                continue;
+            }
+
+            // edge weight dt = distance / max(|V(u)|, v_floor)
+            let s_m = geo::great_circle_arc_len_m(pos_unit[u], pos_unit[v], RADIUS_M);
+            let speed = ((v_en[u][0] as f64).hypot(v_en[u][1] as f64)).max(vfloor);
+            let dt_yr = s_m / speed;
+            let new_t = t_yr + dt_yr;
+            if new_t < dist_yr[v] {
+                dist_yr[v] = new_t;
+                heap.push(QueueItem { t_yr: new_t, cell: v as u32 });
+            }
+        }
+    }
+
+    // Convert to Myr and compute depth via Parsons–Sclater-like map
+    let mut age_myr: Vec<f32> = Vec::with_capacity(grid.cells);
+    let mut depth_m: Vec<f32> = Vec::with_capacity(grid.cells);
+    let (mut amin, mut amax) = (f32::INFINITY, f32::NEG_INFINITY);
+    let (mut dmin, mut dmax) = (f32::INFINITY, f32::NEG_INFINITY);
+    let (d0, a_coef, b_coef) = (2600.0_f64, 350.0_f64, 0.0_f64);
+    for t in &dist_yr {
+        let t_myr = if t.is_finite() { (*t / 1.0e6) as f32 } else { f32::INFINITY };
+        let mut depth = (d0 + a_coef * (t_myr as f64).sqrt() + b_coef * (t_myr as f64)) as f32;
+        if !depth.is_finite() {
+            depth = 6000.0;
+        }
+        depth = depth.clamp(0.0, 6000.0);
+        amin = amin.min(t_myr);
+        amax = amax.max(t_myr);
+        dmin = dmin.min(depth);
+        dmax = dmax.max(depth);
+        age_myr.push(t_myr);
+        depth_m.push(depth);
+    }
+
+    AgeOutputs { age_myr, depth_m, min_max_age: (amin, amax), min_max_depth: (dmin, dmax) }
+}

--- a/aule/engine/src/geo.rs
+++ b/aule/engine/src/geo.rs
@@ -1,0 +1,65 @@
+#![allow(clippy::many_single_char_names)]
+
+/// Dot product of 3D vectors.
+#[inline]
+pub fn dot(a: [f64; 3], b: [f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+/// Cross product of 3D vectors.
+#[inline]
+pub fn cross(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]]
+}
+
+/// Euclidean norm of a 3D vector.
+#[inline]
+pub fn norm(a: [f64; 3]) -> f64 {
+    dot(a, a).sqrt()
+}
+
+/// Normalize a 3D vector (returns zero if input is zero).
+#[inline]
+pub fn normalize(mut a: [f64; 3]) -> [f64; 3] {
+    let n = norm(a);
+    if n > 0.0 {
+        a[0] /= n;
+        a[1] /= n;
+        a[2] /= n;
+    }
+    a
+}
+
+/// Great-circle arc length (meters) between two unit vectors on a sphere of radius `r_m`.
+#[inline]
+pub fn great_circle_arc_len_m(a_unit: [f64; 3], b_unit: [f64; 3], r_m: f64) -> f64 {
+    // angle = atan2(|a×b|, a·b)
+    let c = cross(a_unit, b_unit);
+    let s = norm(c);
+    let d = dot(a_unit, b_unit).clamp(-1.0, 1.0);
+    r_m * s.atan2(d).abs()
+}
+
+/// Local tangent basis at unit position r_hat: (east, north).
+#[inline]
+pub fn local_basis(r_hat: [f64; 3]) -> ([f64; 3], [f64; 3]) {
+    // Use Z as reference; if near-parallel, fall back to Y
+    let z = [0.0_f64, 0.0, 1.0];
+    let mut e = cross(z, r_hat);
+    if norm(e) < 1e-12 {
+        let y = [0.0_f64, 1.0, 0.0];
+        e = cross(y, r_hat);
+    }
+    let east = normalize(e);
+    let north = normalize(cross(r_hat, east));
+    (east, north)
+}
+
+/// Convert local (east,north) components at r̂ into a world-space vector (m/yr).
+#[inline]
+pub fn en_to_world(r_hat: [f64; 3], v_en_m_per_yr: [f32; 2]) -> [f64; 3] {
+    let (e, n) = local_basis(r_hat);
+    let ve = v_en_m_per_yr[0] as f64;
+    let vn = v_en_m_per_yr[1] as f64;
+    [e[0] * ve + n[0] * vn, e[1] * ve + n[1] * vn, e[2] * ve + n[2] * vn]
+}

--- a/aule/engine/src/lib.rs
+++ b/aule/engine/src/lib.rs
@@ -3,10 +3,14 @@
 #![deny(missing_docs)]
 #![deny(clippy::unwrap_used, clippy::expect_used, clippy::dbg_macro, clippy::large_enum_variant)]
 
+/// Steady-state oceanic age and bathymetry mapping.
+pub mod age;
 /// Plate boundary classification.
 pub mod boundaries;
 /// Field and tiling views.
 pub mod fields;
+/// Geometric utilities used by solvers.
+pub mod geo;
 /// Minimal GPU helper for tests (T-020).
 pub mod gpu;
 /// Geodesic grid module.

--- a/aule/engine/src/ridge.rs
+++ b/aule/engine/src/ridge.rs
@@ -64,8 +64,8 @@ pub fn apply_ridge(
     let mut fringe: u32 = 0;
     if params.fringe_age_myr > 0.0 {
         let mut touched = vec![false; n_cells];
-        for u in 0..n_cells {
-            if !is_ridge[u] {
+        for (u, &ridge) in is_ridge.iter().enumerate() {
+            if !ridge {
                 continue;
             }
             for &n in &grid.n1[u] {

--- a/aule/engine/tests/age.rs
+++ b/aule/engine/tests/age.rs
@@ -1,0 +1,20 @@
+use engine::{age, boundaries::Boundaries, grid::Grid, plates::Plates};
+
+#[test]
+fn determinism_and_nonnegativity() {
+    let f: u32 = 16;
+    let g = Grid::new(f);
+    let plates = Plates::new(&g, 4, 1234);
+    let b = Boundaries::classify(&g, &plates.plate_id, &plates.vel_en, 0.005);
+    let p = age::AgeParams { v_floor_m_per_yr: 0.005 };
+    let out1 = age::compute_age_and_bathymetry(&g, &b, &plates.plate_id, &plates.vel_en, p);
+    let out2 = age::compute_age_and_bathymetry(&g, &b, &plates.plate_id, &plates.vel_en, p);
+    assert_eq!(out1.age_myr.len(), g.cells);
+    assert_eq!(out1.depth_m.len(), g.cells);
+    for i in 0..g.cells {
+        assert!(out1.age_myr[i] >= 0.0);
+        assert!(out1.depth_m[i] >= 0.0);
+    }
+    assert_eq!(out1.age_myr, out2.age_myr);
+    assert_eq!(out1.depth_m, out2.depth_m);
+}

--- a/aule/engine/tests/ridge.rs
+++ b/aule/engine/tests/ridge.rs
@@ -29,16 +29,6 @@ fn births_and_fringe_correctness_and_idempotence() {
 
     // Fringe neighbors must be <= fringe cap only for neighbors of ridge cells
     let mut neighbor_mask = vec![false; g.cells];
-    for u in 0..g.cells {
-        // identify ridge cells
-        let mut is_ridge = false;
-        for &n in &g.n1[u] {
-            // Note: ridge defined by divergent edges; check edges to see if this cell is on any divergent edge
-            // Conservatively build ridge mask from edges
-            // We'll just scan edges once per test for simplicity
-            let _ = n; // silence unused in this loop
-        }
-    }
     let mut is_ridge_cell = vec![false; g.cells];
     for &(u, v, class) in &b.edges {
         if class == 1 {
@@ -46,8 +36,8 @@ fn births_and_fringe_correctness_and_idempotence() {
             is_ridge_cell[v as usize] = true;
         }
     }
-    for u in 0..g.cells {
-        if is_ridge_cell[u] {
+    for (u, &is_r) in is_ridge_cell.iter().enumerate() {
+        if is_r {
             for &n in &g.n1[u] {
                 neighbor_mask[n as usize] = true;
             }

--- a/aule/shaders/age_advect.wgsl
+++ b/aule/shaders/age_advect.wgsl
@@ -1,0 +1,4 @@
+// Placeholder WGSL for future age advection kernel (T-060)
+// CPU steady-state solver lives in `engine::age`.
+
+


### PR DESCRIPTION
…erlays

# PR for {TASK_ID}: {TASK_TITLE}

## Summary
- Task card: {link or ID}
- Scope: {one-liner}

## Changes
- Files touched (only those allowed by the card):
  - …

## Acceptance Criteria Matrix
| Criterion | Evidence |
|---|---|
| C1: {quote from card} | {tests/screens, code refs} |
| C2: {…} | {…} |

## Validation
- Unit tests: `cargo test -p engine` → {pass/fail}
- Lints: `cargo clippy -- -D warnings` → {pass}
- Format: `cargo fmt -- --check` → {pass}
- Viewer smoke test: `cargo run -p viewer` (60 FPS idle) → {ok}

## Benchmarks (include numbers)
- Machine/GPU: {e.g., 13700K + RTX 4080}
- Grid: F=256 (cells≈), Step time: {ms}
- Grid: F=512, Step time: {ms}
- Notes: {any perf regressions/mitigations}

## Screenshots / Plots (if applicable)
- Plate overlay / boundaries / age–depth plot

## Docs
- Updated: README, docs pages, public API rustdoc

## Risk/Assumptions
- {any assumptions taken to resolve ambiguity}

## Checklist
- [ ] Matches card ID & title
- [ ] Only allowed files modified
- [ ] New/changed APIs documented
- [ ] Tests updated
- [ ] Benchmarks run & recorded
- [ ] CI green
- [ ] Determinism maintained