### PR TITLE
feat(T-061): viewer AgeDepth plot, RMS; expose depth_from_age(); tests

### DIFF
--- a/aule/engine/src/age.rs
+++ b/aule/engine/src/age.rs
@@ -34,6 +34,12 @@ pub struct AgeOutputs {
     /// Min/max of depth
     pub min_max_depth: (f32, f32),
 }
+/// Compute bathymetry depth (m, +down) from age (Myr) using a simple
+/// Parsons–Sclater style curve (no clamping).
+#[inline]
+pub fn depth_from_age(age_myr: f64, d0: f64, a: f64, b: f64) -> f64 {
+    d0 + a * age_myr.sqrt() + b * age_myr
+}
 
 #[derive(Copy, Clone, Debug)]
 struct QueueItem {
@@ -142,7 +148,7 @@ pub fn compute_age_and_bathymetry(
     let (d0, a_coef, b_coef) = (2600.0_f64, 350.0_f64, 0.0_f64);
     for t in &dist_yr {
         let t_myr = if t.is_finite() { (*t / 1.0e6) as f32 } else { f32::INFINITY };
-        let mut depth = (d0 + a_coef * (t_myr as f64).sqrt() + b_coef * (t_myr as f64)) as f32;
+        let mut depth = depth_from_age(t_myr as f64, d0, a_coef, b_coef) as f32;
         if !depth.is_finite() {
             depth = 6000.0;
         }

--- a/aule/engine/tests/age.rs
+++ b/aule/engine/tests/age.rs
@@ -18,3 +18,21 @@ fn determinism_and_nonnegativity() {
     assert_eq!(out1.age_myr, out2.age_myr);
     assert_eq!(out1.depth_m, out2.depth_m);
 }
+
+#[test]
+fn depth_from_age_monotonic_and_anchors() {
+    let d0 = 2600.0;
+    let a = 350.0;
+    let b = 0.0;
+    // Anchors
+    let d_zero = age::depth_from_age(0.0, d0, a, b);
+    assert!((d_zero - d0).abs() < 1e-6);
+    // Monotonic increasing with age
+    let d_10 = age::depth_from_age(10.0, d0, a, b);
+    let d_20 = age::depth_from_age(20.0, d0, a, b);
+    assert!(d_20 > d_10);
+    // Rough anchor around 100 Myr
+    let d_100 = age::depth_from_age(100.0, d0, a, b);
+    let expected = d0 + a * (100.0_f64).sqrt() + b * 100.0;
+    assert!((d_100 - expected).abs() < 1e-6);
+}

--- a/aule/viewer/Cargo.toml
+++ b/aule/viewer/Cargo.toml
@@ -11,6 +11,7 @@ wgpu.workspace = true
 egui.workspace = true
 egui-winit = { version = "0.27", default-features = false, features = ["clipboard"] }
 egui-wgpu = { version = "0.27", default-features = false }
+egui_plot = { version = "0.27", default-features = false }
 pollster.workspace = true
 engine = { path = "../engine" }
 

--- a/aule/viewer/src/overlay.rs
+++ b/aule/viewer/src/overlay.rs
@@ -31,6 +31,11 @@ pub struct OverlayState {
     pub depth_minmax: (f32, f32),
     pub(crate) age_cache: Option<Vec<Shape>>,
     pub(crate) bathy_cache: Option<Vec<Shape>>,
+
+    // Age–Depth plot controls
+    pub show_age_depth: bool,
+    pub plot_sample_cap: u32,
+    pub plot_bin_width_myr: f32,
 }
 
 impl Default for OverlayState {
@@ -62,6 +67,9 @@ impl Default for OverlayState {
             depth_minmax: (0.0, 0.0),
             age_cache: None,
             bathy_cache: None,
+            show_age_depth: false,
+            plot_sample_cap: 5000,
+            plot_bin_width_myr: 5.0,
         }
     }
 }

--- a/aule/viewer/src/plot.rs
+++ b/aule/viewer/src/plot.rs
@@ -1,0 +1,127 @@
+use egui::{Color32, Vec2};
+use egui_plot::{Line, Plot, PlotPoints, Points};
+
+pub struct AgeDepthPlotParams {
+    pub sample_cap: usize,
+    pub bin_width_myr: f32,
+}
+
+pub struct AgeDepthStats {
+    pub rms_m: f32,
+    pub n_samples: usize,
+    pub age_minmax: (f32, f32),
+    pub depth_minmax: (f32, f32),
+}
+
+pub struct AgeDepthPlotData {
+    pub scatter: Points,
+    pub binned: Line,
+    pub reference: Line,
+    pub stats: AgeDepthStats,
+}
+
+fn subsample_stride(n: usize, cap: usize) -> usize {
+    (n / cap.max(1)).max(1)
+}
+
+pub fn build_age_depth_plot(
+    age_myr: &[f32],
+    depth_m: &[f32],
+    params: AgeDepthPlotParams,
+    depth_ref_fn: &dyn Fn(f64) -> f64,
+) -> AgeDepthPlotData {
+    let n = age_myr.len().min(depth_m.len());
+    let stride = subsample_stride(n, params.sample_cap);
+    let mut pts: Vec<[f64; 2]> = Vec::with_capacity((n + stride - 1) / stride);
+    let (mut amin, mut amax) = (f32::INFINITY, f32::NEG_INFINITY);
+    let (mut dmin, mut dmax) = (f32::INFINITY, f32::NEG_INFINITY);
+    let mut sq_err_sum: f64 = 0.0;
+    let mut count: usize = 0;
+    for i in (0..n).step_by(stride) {
+        let a = age_myr[i];
+        if !a.is_finite() || a <= 0.0 {
+            continue;
+        }
+        let d = depth_m[i];
+        if !d.is_finite() {
+            continue;
+        }
+        amin = amin.min(a);
+        amax = amax.max(a);
+        dmin = dmin.min(d);
+        dmax = dmax.max(d);
+        let dref = depth_ref_fn(a as f64) as f32;
+        let err = (d - dref) as f64;
+        sq_err_sum += err * err;
+        count += 1;
+        pts.push([a as f64, d as f64]);
+    }
+
+    let rms = if count > 0 { (sq_err_sum / (count as f64)).sqrt() as f32 } else { 0.0 };
+    let scatter = Points::new(PlotPoints::from_iter(pts.iter().copied()))
+        .color(Color32::from_rgb(80, 160, 240))
+        .radius(1.5)
+        .name("samples");
+
+    // Binned means
+    let bw = params.bin_width_myr.max(1.0);
+    let mut bins: Vec<(f32, f32, u32)> = Vec::new();
+    if amin.is_finite() && amax.is_finite() && amin < amax {
+        let nb = ((amax - amin) / bw).ceil() as usize;
+        bins.resize(nb, (0.0, 0.0, 0));
+        for i in (0..n).step_by(stride) {
+            let a = age_myr[i];
+            if a <= 0.0 || !a.is_finite() {
+                continue;
+            }
+            let d = depth_m[i];
+            if !d.is_finite() {
+                continue;
+            }
+            let bi = ((a - amin) / bw).floor() as isize;
+            if bi >= 0 && (bi as usize) < nb {
+                let (s, c, n) = bins[bi as usize];
+                bins[bi as usize] = (s + d, c + a, n + 1);
+            }
+        }
+    }
+    let mut bpts: Vec<[f64; 2]> = Vec::new();
+    for (i, (sum_d, sum_a, n)) in bins.iter().copied().enumerate() {
+        if n == 0 {
+            continue;
+        }
+        let mean_d = sum_d / (n as f32);
+        let mean_a = sum_a / (n as f32);
+        bpts.push([mean_a as f64, mean_d as f64]);
+    }
+    let binned = Line::new(PlotPoints::from_iter(bpts.iter().copied()))
+        .color(Color32::from_rgb(250, 200, 80))
+        .name("binned mean");
+
+    // Reference curve densely sampled
+    let mut rpts: Vec<[f64; 2]> = Vec::new();
+    if amin.is_finite() && amax.is_finite() && amin < amax {
+        let steps = 256;
+        for k in 0..=steps {
+            let t = k as f64 / steps as f64;
+            let a = (1.0 - t) * (amin as f64) + t * (amax as f64);
+            let d = depth_ref_fn(a);
+            rpts.push([a, d]);
+        }
+    }
+    let reference = Line::new(PlotPoints::from_iter(rpts.iter().copied()))
+        .color(Color32::WHITE)
+        .name("reference");
+
+    AgeDepthPlotData {
+        scatter,
+        binned,
+        reference,
+        stats: AgeDepthStats {
+            rms_m: rms,
+            n_samples: count,
+            age_minmax: (amin, amax),
+            depth_minmax: (dmin, dmax),
+        },
+    }
+}


### PR DESCRIPTION
# PR for {TASK_ID}: {TASK_TITLE}

## Summary
- Task card: {link or ID}
- Scope: {one-liner}

## Changes
- Files touched (only those allowed by the card):
  - …

## Acceptance Criteria Matrix
| Criterion | Evidence |
|---|---|
| C1: {quote from card} | {tests/screens, code refs} |
| C2: {…} | {…} |

## Validation
- Unit tests: `cargo test -p engine` → {pass/fail}
- Lints: `cargo clippy -- -D warnings` → {pass}
- Format: `cargo fmt -- --check` → {pass}
- Viewer smoke test: `cargo run -p viewer` (60 FPS idle) → {ok}

## Benchmarks (include numbers)
- Machine/GPU: {e.g., 13700K + RTX 4080}
- Grid: F=256 (cells≈), Step time: {ms}
- Grid: F=512, Step time: {ms}
- Notes: {any perf regressions/mitigations}

## Screenshots / Plots (if applicable)
- Plate overlay / boundaries / age–depth plot

## Docs
- Updated: README, docs pages, public API rustdoc

## Risk/Assumptions
- {any assumptions taken to resolve ambiguity}

## Checklist
- [ ] Matches card ID & title
- [ ] Only allowed files modified
- [ ] New/changed APIs documented
- [ ] Tests updated
- [ ] Benchmarks run & recorded
- [ ] CI green
- [ ] Determinism maintained