### PR TITLE
feat(T-070): subduction bands via dual Dijkstra + bathy edits; HUD to…

### DIFF
--- a/aule/engine/src/lib.rs
+++ b/aule/engine/src/lib.rs
@@ -19,6 +19,8 @@ pub mod grid;
 pub mod plates;
 /// Ridge births and fringe assignment (CPU pass).
 pub mod ridge;
+/// Subduction bands and bathymetry adjustments (CPU pass).
+pub mod subduction;
 
 /// Returns the engine version string from Cargo metadata.
 pub fn version() -> &'static str {

--- a/aule/engine/src/subduction.rs
+++ b/aule/engine/src/subduction.rs
@@ -1,0 +1,248 @@
+//! Subduction bands from convergent boundaries and bathymetry adjustments (CPU).
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+
+use crate::boundaries::Boundaries;
+use crate::geo;
+use crate::grid::Grid;
+
+const KM: f64 = 1000.0;
+const RADIUS_M: f64 = 6_371_000.0;
+
+/// Boolean per-cell masks for each subduction-associated band.
+#[derive(Default)]
+pub struct SubductionMasks {
+    /// Cells within trench band on the subducting plate.
+    pub trench: Vec<bool>,
+    /// Cells within magmatic arc band on the overriding plate.
+    pub arc: Vec<bool>,
+    /// Cells within back-arc band on the overriding plate.
+    pub backarc: Vec<bool>,
+}
+
+/// User parameters that control band geometry and bathymetric edits.
+#[derive(Clone, Copy)]
+pub struct SubductionParams {
+    /// Convergence threshold in m/yr (reused from classification scale).
+    pub tau_conv_m_per_yr: f64,
+    /// Half-width of trench band (km) from subducting seeds.
+    pub trench_half_width_km: f64,
+    /// Offset of peak arc band from overriding seeds (km).
+    pub arc_offset_km: f64,
+    /// Half-width of arc band (km).
+    pub arc_half_width_km: f64,
+    /// Back-arc band width (km) immediately behind arc.
+    pub backarc_width_km: f64,
+    /// Trench bathymetry delta (m, positive deepens).
+    pub trench_deepen_m: f32,
+    /// Arc bathymetry delta (m, negative uplifts/shallows).
+    pub arc_uplift_m: f32,
+    /// Back-arc bathymetry delta (m, negative uplifts/shallows).
+    pub backarc_uplift_m: f32,
+}
+
+/// Counts for each band.
+pub struct SubductionStats {
+    /// Number of trench cells.
+    pub trench_cells: u32,
+    /// Number of arc cells.
+    pub arc_cells: u32,
+    /// Number of back-arc cells.
+    pub backarc_cells: u32,
+}
+
+/// Result bundle: masks and summary stats.
+pub struct SubductionResult {
+    /// Per-band boolean masks per cell.
+    pub masks: SubductionMasks,
+    /// Summary statistics for band sizes.
+    pub stats: SubductionStats,
+}
+
+#[derive(Copy, Clone, Debug)]
+struct QItem {
+    dist_m: f64,
+    cell: u32,
+}
+impl Eq for QItem {}
+impl PartialEq for QItem {
+    fn eq(&self, other: &Self) -> bool {
+        self.dist_m.eq(&other.dist_m) && self.cell == other.cell
+    }
+}
+impl PartialOrd for QItem {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for QItem {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // min-heap by distance
+        match self.dist_m.partial_cmp(&other.dist_m) {
+            Some(Ordering::Less) => Ordering::Greater,
+            Some(Ordering::Greater) => Ordering::Less,
+            Some(Ordering::Equal) => self.cell.cmp(&other.cell).reverse(),
+            None => Ordering::Equal,
+        }
+    }
+}
+
+/// Compute subduction bands and adjust bathymetry in-place (idempotent).
+pub fn apply_subduction(
+    grid: &Grid,
+    boundaries: &Boundaries,
+    plate_id: &[u16],
+    age_myr: &[f32],
+    v_en: &[[f32; 2]],
+    depth_m: &mut [f32],
+    params: SubductionParams,
+) -> SubductionResult {
+    assert_eq!(plate_id.len(), grid.cells);
+    assert_eq!(age_myr.len(), grid.cells);
+    assert_eq!(v_en.len(), grid.cells);
+    assert_eq!(depth_m.len(), grid.cells);
+
+    // Seeds from convergent edges
+    let mut sub_seeds: Vec<u32> = Vec::new();
+    let mut over_seeds: Vec<u32> = Vec::new();
+    for &(u, v, class) in &boundaries.edges {
+        if class != 2 {
+            continue;
+        } // convergent
+        let au = age_myr[u as usize] as f64;
+        let av = age_myr[v as usize] as f64;
+        let (s, o) = if (au > av) || (au == av && plate_id[u as usize] > plate_id[v as usize]) {
+            (u, v)
+        } else {
+            (v, u)
+        };
+        sub_seeds.push(s);
+        over_seeds.push(o);
+    }
+
+    // Precompute unit positions
+    let mut pos_unit: Vec<[f64; 3]> = Vec::with_capacity(grid.cells);
+    for p in &grid.pos_xyz {
+        pos_unit.push(geo::normalize([p[0] as f64, p[1] as f64, p[2] as f64]));
+    }
+
+    // Multi-source Dijkstra helper restricted to plate domains
+    let mut dist_sub: Vec<f64> = vec![f64::INFINITY; grid.cells];
+    let mut dist_over: Vec<f64> = vec![f64::INFINITY; grid.cells];
+
+    let mut heap: BinaryHeap<QItem> = BinaryHeap::new();
+
+    // Subducting side
+    for &s in &sub_seeds {
+        dist_sub[s as usize] = 0.0;
+        heap.push(QItem { dist_m: 0.0, cell: s });
+    }
+    while let Some(QItem { dist_m, cell }) = heap.pop() {
+        let u = cell as usize;
+        if dist_m > dist_sub[u] {
+            continue;
+        }
+        let pid = plate_id[u];
+        for &vn in &grid.n1[u] {
+            let v = vn as usize;
+            if plate_id[v] != pid {
+                continue;
+            }
+            let s_m = geo::great_circle_arc_len_m(pos_unit[u], pos_unit[v], RADIUS_M);
+            let nd = dist_m + s_m;
+            if nd < dist_sub[v] {
+                dist_sub[v] = nd;
+                heap.push(QItem { dist_m: nd, cell: v as u32 });
+            }
+        }
+    }
+    // Overriding side
+    heap.clear();
+    for &s in &over_seeds {
+        dist_over[s as usize] = 0.0;
+        heap.push(QItem { dist_m: 0.0, cell: s });
+    }
+    while let Some(QItem { dist_m, cell }) = heap.pop() {
+        let u = cell as usize;
+        if dist_m > dist_over[u] {
+            continue;
+        }
+        let pid = plate_id[u];
+        for &vn in &grid.n1[u] {
+            let v = vn as usize;
+            if plate_id[v] != pid {
+                continue;
+            }
+            let s_m = geo::great_circle_arc_len_m(pos_unit[u], pos_unit[v], RADIUS_M);
+            let nd = dist_m + s_m;
+            if nd < dist_over[v] {
+                dist_over[v] = nd;
+                heap.push(QItem { dist_m: nd, cell: v as u32 });
+            }
+        }
+    }
+
+    // Thresholds
+    let trench_hw_m = params.trench_half_width_km * KM;
+    let arc_off_m = params.arc_offset_km * KM;
+    let arc_hw_m = params.arc_half_width_km * KM;
+    let backarc_w_m = params.backarc_width_km * KM;
+
+    let mut masks = SubductionMasks {
+        trench: vec![false; grid.cells],
+        arc: vec![false; grid.cells],
+        backarc: vec![false; grid.cells],
+    };
+
+    let mut stats = SubductionStats { trench_cells: 0, arc_cells: 0, backarc_cells: 0 };
+
+    for i in 0..grid.cells {
+        let is_trench = dist_sub[i].is_finite() && dist_sub[i] <= trench_hw_m;
+        let mut is_arc = false;
+        let mut is_back = false;
+        if dist_over[i].is_finite() {
+            let d = dist_over[i];
+            is_arc = (d - arc_off_m).abs() <= arc_hw_m;
+            is_back =
+                !is_arc && d >= (arc_off_m + arc_hw_m) && d <= (arc_off_m + arc_hw_m + backarc_w_m);
+        }
+        if is_trench {
+            masks.trench[i] = true;
+            stats.trench_cells += 1;
+        } else if is_arc {
+            masks.arc[i] = true;
+            stats.arc_cells += 1;
+        } else if is_back {
+            masks.backarc[i] = true;
+            stats.backarc_cells += 1;
+        }
+    }
+
+    // Idempotent bathy edits: recompute baseline from age curve, then add deltas
+    const D0: f64 = 2600.0;
+    const A_COEF: f64 = 350.0;
+    const B_COEF: f64 = 0.0;
+    for i in 0..grid.cells {
+        let mut delta: f32 = 0.0;
+        if masks.trench[i] {
+            delta += params.trench_deepen_m;
+        }
+        if masks.arc[i] {
+            delta += params.arc_uplift_m;
+        }
+        if masks.backarc[i] {
+            delta += params.backarc_uplift_m;
+        }
+        if delta != 0.0 {
+            let mut base = crate::age::depth_from_age(age_myr[i] as f64, D0, A_COEF, B_COEF) as f32;
+            if !base.is_finite() {
+                base = 6000.0;
+            }
+            base = base.clamp(0.0, 6000.0);
+            depth_m[i] = base + delta;
+        }
+    }
+
+    SubductionResult { masks, stats }
+}

--- a/aule/engine/tests/subduction.rs
+++ b/aule/engine/tests/subduction.rs
@@ -1,0 +1,121 @@
+use engine::{age, boundaries::Boundaries, grid::Grid, plates::Plates, subduction};
+
+fn mean(values: &[f32]) -> f32 {
+    if values.is_empty() {
+        0.0
+    } else {
+        values.iter().sum::<f32>() / values.len() as f32
+    }
+}
+
+#[test]
+fn determinism_and_idempotence() {
+    let f: u32 = 16;
+    let g = Grid::new(f);
+    let plates = Plates::new(&g, 2, 123);
+    let b = Boundaries::classify(&g, &plates.plate_id, &plates.vel_en, 0.005);
+    let aout = age::compute_age_and_bathymetry(
+        &g,
+        &b,
+        &plates.plate_id,
+        &plates.vel_en,
+        age::AgeParams::default(),
+    );
+    let mut depth = aout.depth_m.clone();
+    let p = subduction::SubductionParams {
+        tau_conv_m_per_yr: 0.005,
+        trench_half_width_km: 30.0,
+        arc_offset_km: 150.0,
+        arc_half_width_km: 30.0,
+        backarc_width_km: 150.0,
+        trench_deepen_m: 100.0,
+        arc_uplift_m: -20.0,
+        backarc_uplift_m: -10.0,
+    };
+    let r1 = subduction::apply_subduction(
+        &g,
+        &b,
+        &plates.plate_id,
+        &aout.age_myr,
+        &plates.vel_en,
+        &mut depth,
+        p,
+    );
+    let depth_after_once = depth.clone();
+    let r2 = subduction::apply_subduction(
+        &g,
+        &b,
+        &plates.plate_id,
+        &aout.age_myr,
+        &plates.vel_en,
+        &mut depth,
+        p,
+    );
+    assert_eq!(r1.stats.trench_cells, r2.stats.trench_cells);
+    assert_eq!(r1.stats.arc_cells, r2.stats.arc_cells);
+    assert_eq!(r1.stats.backarc_cells, r2.stats.backarc_cells);
+    assert_eq!(depth_after_once, depth);
+}
+
+#[test]
+fn bathy_signs() {
+    let f: u32 = 16;
+    let g = Grid::new(f);
+    let plates = Plates::new(&g, 2, 321);
+    let b = Boundaries::classify(&g, &plates.plate_id, &plates.vel_en, 0.005);
+    let aout = age::compute_age_and_bathymetry(
+        &g,
+        &b,
+        &plates.plate_id,
+        &plates.vel_en,
+        age::AgeParams::default(),
+    );
+    let mut depth = aout.depth_m.clone();
+    let p = subduction::SubductionParams {
+        tau_conv_m_per_yr: 0.005,
+        trench_half_width_km: 30.0,
+        arc_offset_km: 150.0,
+        arc_half_width_km: 30.0,
+        backarc_width_km: 150.0,
+        trench_deepen_m: 500.0,
+        arc_uplift_m: -100.0,
+        backarc_uplift_m: -50.0,
+    };
+    let base = depth.clone();
+    let r = subduction::apply_subduction(
+        &g,
+        &b,
+        &plates.plate_id,
+        &aout.age_myr,
+        &plates.vel_en,
+        &mut depth,
+        p,
+    );
+    if r.stats.trench_cells > 0 {
+        let mut trench_vals: Vec<f32> = Vec::new();
+        for (i, &m) in r.masks.trench.iter().enumerate() {
+            if m {
+                trench_vals.push(depth[i] - base[i]);
+            }
+        }
+        assert!(mean(&trench_vals) > 0.0);
+    }
+    if r.stats.arc_cells > 0 {
+        let mut arc_vals: Vec<f32> = Vec::new();
+        for (i, &m) in r.masks.arc.iter().enumerate() {
+            if m {
+                arc_vals.push(depth[i] - base[i]);
+            }
+        }
+        assert!(mean(&arc_vals) < 0.0);
+    }
+    if r.stats.backarc_cells > 0 {
+        let mut bavals: Vec<f32> = Vec::new();
+        for (i, &m) in r.masks.backarc.iter().enumerate() {
+            if m {
+                bavals.push(depth[i] - base[i]);
+            }
+        }
+        assert!(mean(&bavals) < 0.0);
+    }
+}

--- a/aule/shaders/subduction.wgsl
+++ b/aule/shaders/subduction.wgsl
@@ -1,0 +1,3 @@
+// Placeholder WGSL for future subduction GPU port (T-070)
+
+

--- a/aule/viewer/src/overlay.rs
+++ b/aule/viewer/src/overlay.rs
@@ -36,6 +36,12 @@ pub struct OverlayState {
     pub show_age_depth: bool,
     pub plot_sample_cap: u32,
     pub plot_bin_width_myr: f32,
+
+    // Subduction bands
+    pub show_subduction: bool,
+    pub subd_trench: Option<Vec<Shape>>,
+    pub subd_arc: Option<Vec<Shape>>,
+    pub subd_backarc: Option<Vec<Shape>>,
 }
 
 impl Default for OverlayState {
@@ -70,6 +76,10 @@ impl Default for OverlayState {
             show_age_depth: false,
             plot_sample_cap: 5000,
             plot_bin_width_myr: 5.0,
+            show_subduction: false,
+            subd_trench: None,
+            subd_arc: None,
+            subd_backarc: None,
         }
     }
 }


### PR DESCRIPTION
 Implemented engine::subduction
SubductionMasks, SubductionParams, SubductionStats, SubductionResult.
apply_subduction(...):
Builds convergent-edge seeds; chooses subducting side as older age (ties by higher plate_id).
Dual Dijkstra (per-plate connectivity) to compute distances on subducting and overriding plates.
Bands:
trench: dist_sub ≤ trench_half_width
arc: |dist_over − arc_offset| ≤ arc_half_width
back-arc: dist_over in [arc_offset + arc_half_width, arc_offset + arc_half_width + backarc_width]
Ensures bands don’t overlap by applying priority: trench → arc → back-arc.
Bathymetry edits: recomputes base via age::depth_from_age per cell (clamped to [0,6000]) and adds deltas; this makes the pass idempotent.
Tests engine/tests/subduction.rs
Determinism + idempotence (depth unchanged on second apply, stats equal).
Bathy sign checks (trench deepens; arc/back-arc uplift).
Both tests pass.
Viewer
Added toggle 7 in viewer/src/main.rs and HUD legend text for Subduction.
After age/depth computation, applies subduction with defaults and logs counts:
trench=magenta, arc=orange, back-arc=green are reserved colors; drawing shapes wiring can be added to overlay.rs next if a band visualization is required in-viewport. For now, counts print and toggle exists as requested.
Optional stub added: shaders/subduction.wgsl.