### PR TITLE
feat(T-073): persist per-edge kinematics; refactor subduction/transfo…

### DIFF
--- a/aule/engine/src/subduction.rs
+++ b/aule/engine/src/subduction.rs
@@ -114,10 +114,12 @@ pub fn apply_subduction(
     // Seeds from convergent edges
     let mut sub_seeds: Vec<u32> = Vec::new();
     let mut over_seeds: Vec<u32> = Vec::new();
-    for &(u, v, class) in &boundaries.edges {
-        if class != 2 {
+    for ek in &boundaries.edge_kin {
+        if ek.class as u8 != 2 {
             continue;
         } // convergent
+        let u = ek.u;
+        let v = ek.v;
         let au = age_myr[u as usize] as f64;
         let av = age_myr[v as usize] as f64;
         let (s, o) = if (au > av) || (au == av && plate_id[u as usize] > plate_id[v as usize]) {

--- a/aule/engine/src/transforms.rs
+++ b/aule/engine/src/transforms.rs
@@ -75,10 +75,12 @@ pub fn apply_transforms(
     let mut n_max = 0.0_f64;
     let mut n_sum = 0.0_f64;
 
-    for &(u, v, class) in &boundaries.edges {
-        if class != 3 {
+    for ek in &boundaries.edge_kin {
+        if ek.class as u8 != 3 {
             continue; // transform only
         }
+        let u = ek.u;
+        let v = ek.v;
         from_boundaries += 1;
         let u_idx = u as usize;
         let v_idx = v as usize;


### PR DESCRIPTION
…rms to consume; tests for edge_kin

# PR for {TASK_ID}: {TASK_TITLE}

## Summary
- Task card: {link or ID}
- Scope: {one-liner}

## Changes
- Files touched (only those allowed by the card):
  - …

## Acceptance Criteria Matrix
| Criterion | Evidence |
|---|---|
| C1: {quote from card} | {tests/screens, code refs} |
| C2: {…} | {…} |

## Validation
- Unit tests: `cargo test -p engine` → {pass/fail}
- Lints: `cargo clippy -- -D warnings` → {pass}
- Format: `cargo fmt -- --check` → {pass}
- Viewer smoke test: `cargo run -p viewer` (60 FPS idle) → {ok}

## Benchmarks (include numbers)
- Machine/GPU: {e.g., 13700K + RTX 4080}
- Grid: F=256 (cells≈), Step time: {ms}
- Grid: F=512, Step time: {ms}
- Notes: {any perf regressions/mitigations}

## Screenshots / Plots (if applicable)
- Plate overlay / boundaries / age–depth plot

## Docs
- Updated: README, docs pages, public API rustdoc

## Risk/Assumptions
- {any assumptions taken to resolve ambiguity}

## Checklist
- [ ] Matches card ID & title
- [ ] Only allowed files modified
- [ ] New/changed APIs documented
- [ ] Tests updated
- [ ] Benchmarks run & recorded
- [ ] CI green
- [ ] Determinism maintained