### PR TITLE
feat(T-080a): CPU flexure reference (1D) with analytic line-load; CG …

### DIFF
--- a/aule/engine/src/flexure.rs
+++ b/aule/engine/src/flexure.rs
@@ -1,0 +1,122 @@
+//! 1D elastic plate flexure on a Winkler foundation (CPU reference).
+//!
+//! Equation: D w''''(x) + k w(x) = q(x)
+//! - D: plate rigidity (Pa·m^3)
+//! - k: foundation stiffness (N/m^3)
+//! - q: load per unit length (N/m)
+//!
+//! Analytic line load solution for q(x) = P δ(x):
+//! w(x) = (P / (2 k α)) exp(-|x|/α) [cos(|x|/α) + sin(|x|/α)]
+
+/// Compute plate rigidity from elastic thickness.
+pub fn d_from_te(e_pa: f64, nu: f64, te_m: f64) -> f64 {
+    let denom = 12.0 * (1.0 - nu * nu);
+    e_pa * te_m.powi(3) / denom
+}
+
+/// Flexural parameter α = (4D/k)^(1/4).
+pub fn alpha(d: f64, k: f64) -> f64 {
+    ((4.0 * d) / k).powf(0.25)
+}
+
+/// Analytic deflection for a line load on an infinite plate.
+pub fn w_line_analytic(x: f64, p_n_per_m: f64, d: f64, k: f64) -> f64 {
+    let a = alpha(d, k);
+    let s = (x.abs()) / a;
+    let pref = p_n_per_m / (2.0 * k * a);
+    pref * (-s).exp() * (s.cos() + s.sin())
+}
+
+/// Result of the CG solve for 1D flexure.
+#[derive(Debug, Clone)]
+pub struct FlexSolve {
+    /// Deflection (m), length N.
+    pub w: Vec<f64>,
+    /// Iterations used.
+    pub iters: usize,
+    /// Final residual 2-norm.
+    pub resid: f64,
+}
+
+/// Apply bi-harmonic 5-point stencil to vector `v` into `out` (zero BC beyond ends).
+fn apply_biharmonic_5(v: &[f64], out: &mut [f64], inv_dx4: f64) {
+    let n = v.len();
+    out.fill(0.0);
+    if n == 0 {
+        return;
+    }
+    for i in 0..n {
+        let w_im2 = if i >= 2 { v[i - 2] } else { 0.0 };
+        let w_im1 = if i >= 1 { v[i - 1] } else { 0.0 };
+        let w_ip1 = if i + 1 < n { v[i + 1] } else { 0.0 };
+        let w_ip2 = if i + 2 < n { v[i + 2] } else { 0.0 };
+        let val = (w_im2 - 4.0 * w_im1 + 6.0 * v[i] - 4.0 * w_ip1 + w_ip2) * inv_dx4;
+        out[i] = val;
+    }
+}
+
+/// Conjugate Gradient solve of (D*bi4 + k*I) w = q, with homogeneous Dirichlet at ends via zero stencil.
+pub fn solve_flexure_1d(
+    q: &[f64],
+    dx: f64,
+    d: f64,
+    k: f64,
+    tol: f64,
+    max_iter: usize,
+) -> FlexSolve {
+    let n = q.len();
+    let inv_dx4 = 1.0 / (dx * dx * dx * dx);
+    let mut w = vec![0.0f64; n];
+    let mut r = q.to_vec();
+    // r = q - A w (w=0 initially)
+    let mut p = r.clone();
+    let mut ap = vec![0.0f64; n];
+    let mut tmp = vec![0.0f64; n];
+    let mut rsold = r.iter().map(|x| x * x).sum::<f64>();
+    let mut resid = rsold.sqrt();
+    let mut iters = 0usize;
+    if resid <= tol {
+        return FlexSolve { w, iters, resid };
+    }
+    for it in 0..max_iter {
+        // ap = D*bi4(p) + k*p
+        apply_biharmonic_5(&p, &mut tmp, inv_dx4);
+        for i in 0..n {
+            ap[i] = d * tmp[i] + k * p[i];
+        }
+        let denom = p.iter().zip(ap.iter()).map(|(pi, api)| pi * api).sum::<f64>();
+        if denom == 0.0 {
+            break;
+        }
+        let alpha_cg = rsold / denom;
+        for i in 0..n {
+            w[i] += alpha_cg * p[i];
+        }
+        for i in 0..n {
+            r[i] -= alpha_cg * ap[i];
+        }
+        let rsnew = r.iter().map(|x| x * x).sum::<f64>();
+        resid = rsnew.sqrt();
+        iters = it + 1;
+        if resid <= tol {
+            break;
+        }
+        let beta = rsnew / rsold;
+        for i in 0..n {
+            p[i] = r[i] + beta * p[i];
+        }
+        rsold = rsnew;
+    }
+    FlexSolve { w, iters, resid }
+}
+
+/// Build a symmetric grid RHS for a single line load centered at index i0.
+pub fn line_load_rhs(n: usize, dx: f64, p_n_per_m: f64) -> Vec<f64> {
+    let mut q = vec![0.0f64; n];
+    if n == 0 {
+        return q;
+    }
+    let i0 = n / 2;
+    q[i0] = p_n_per_m / dx;
+    q
+}

--- a/aule/engine/src/lib.rs
+++ b/aule/engine/src/lib.rs
@@ -9,6 +9,8 @@ pub mod age;
 pub mod boundaries;
 /// Field and tiling views.
 pub mod fields;
+/// 1D elastic plate flexure (CPU reference; analytic + CG solver).
+pub mod flexure;
 /// Geometric utilities used by solvers.
 pub mod geo;
 /// Minimal GPU helper for tests (T-020).

--- a/aule/engine/tests/flexure.rs
+++ b/aule/engine/tests/flexure.rs
@@ -1,0 +1,48 @@
+use engine::flexure::{alpha, d_from_te, line_load_rhs, solve_flexure_1d, w_line_analytic};
+
+#[test]
+fn alpha_monotonicity() {
+    let k = 2.5e5; // choose k so that alpha is O(60–100 km)
+    let d1 = d_from_te(70e9, 0.25, 10_000.0);
+    let d2 = d_from_te(70e9, 0.25, 20_000.0);
+    let a1 = alpha(d1, k);
+    let a2 = alpha(d2, k);
+    assert!(a2 > a1);
+}
+
+#[test]
+fn numeric_matches_analytic_line_load() {
+    // Parameters (SI)
+    let e = 70e9;
+    let nu = 0.25;
+    let te = 25_000.0;
+    let k = 2.5e5; // larger alpha for adequate grid resolution
+    let p = 1.0e12;
+    let d = d_from_te(e, nu, te);
+    let a = alpha(d, k);
+    // Grid
+    let dx = 5_000.0;
+    let n = 1025usize; // ~5,120 km
+    let q = line_load_rhs(n, dx, p);
+    let sol = solve_flexure_1d(&q, dx, d, k, 1e-8, 20_000);
+    assert!(sol.iters < 5_000);
+    // Compare RMS in interior |x| <= 4α
+    let i0 = n / 2;
+    let xmax = 4.0 * a;
+    let imax = ((xmax / dx).floor() as isize).min(i0 as isize);
+    let mut sum2 = 0.0;
+    let mut sum2_ref = 0.0;
+    let mut count = 0.0;
+    for di in -(imax as isize)..=(imax as isize) {
+        let i = (i0 as isize + di) as usize;
+        let x = (di as f64) * dx;
+        let wa = w_line_analytic(x, p, d, k);
+        let wn = sol.w[i];
+        sum2 += (wn - wa) * (wn - wa);
+        sum2_ref += wa * wa;
+        count += 1.0;
+    }
+    let rms = (sum2 / count).sqrt();
+    let ref_rms = (sum2_ref / count).sqrt();
+    assert!(rms / ref_rms <= 0.05, "rms/peak = {}", rms / ref_rms);
+}

--- a/aule/viewer/src/main.rs
+++ b/aule/viewer/src/main.rs
@@ -3,6 +3,7 @@
 
 mod overlay;
 mod plot;
+mod plot_flexure;
 
 use egui_wgpu::Renderer as EguiRenderer;
 use egui_wgpu::ScreenDescriptor;
@@ -182,6 +183,7 @@ fn main() {
     let surface_format = gpu.config.format;
     let mut egui_renderer = EguiRenderer::new(&gpu.device, surface_format, None, 1);
     let mut ov = overlay::OverlayState::default();
+    let mut flex = plot_flexure::FlexureUI::default();
     // T-020: Construct device field buffers sized to the grid (then drop)
     {
         let f: u32 = 64;
@@ -249,6 +251,7 @@ fn main() {
                             if ctx.input(|i| i.key_pressed(egui::Key::Num6)) { ov.show_age_depth = !ov.show_age_depth; }
                             if ctx.input(|i| i.key_pressed(egui::Key::Num7)) { ov.show_subduction = !ov.show_subduction; ov.subd_trench=None; ov.subd_arc=None; ov.subd_backarc=None; }
                             if ctx.input(|i| i.key_pressed(egui::Key::Num0)) { ov.show_transforms = !ov.show_transforms; ov.trans_pull=None; ov.trans_rest=None; }
+                            if ctx.input(|i| i.key_pressed(egui::Key::F)) { flex.show = !flex.show; if flex.show { flex.recompute(); } }
                             if ctx.input(|i| i.key_pressed(egui::Key::H)) { ov.show_hud = !ov.show_hud; }
 
                             egui::TopBottomPanel::top("hud").show_animated(ctx, ov.show_hud, |ui| {
@@ -393,6 +396,12 @@ fn main() {
                                             plot_ui.line(pdata.binned);
                                             plot_ui.line(pdata.reference);
                                         });
+                                });
+                            }
+
+                            if flex.show {
+                                egui::TopBottomPanel::bottom("flexure_panel").show(ctx, |ui| {
+                                    flex.ui(ui);
                                 });
                             }
 

--- a/aule/viewer/src/plot_flexure.rs
+++ b/aule/viewer/src/plot_flexure.rs
@@ -1,0 +1,126 @@
+use egui::{Slider, Ui};
+use egui_plot::{Line, Plot, PlotPoints, Points};
+
+pub struct FlexureUI {
+    pub show: bool,
+    pub e_pa: f64,
+    pub nu: f64,
+    pub te_m: f64,
+    pub k_npm3: f64,
+    pub p_npm: f64,
+    pub dx_m: f64,
+    pub n: usize,
+    // cached
+    alpha_km: f64,
+    iters: usize,
+    resid: f64,
+    rms: f64,
+    analytic: Vec<[f64; 2]>,
+    numeric: Vec<[f64; 2]>,
+}
+
+impl Default for FlexureUI {
+    fn default() -> Self {
+        Self {
+            show: false,
+            e_pa: 70e9,
+            nu: 0.25,
+            te_m: 25_000.0,
+            k_npm3: 3.0e8,
+            p_npm: 1.0e12,
+            dx_m: 5_000.0,
+            n: 1025,
+            alpha_km: 0.0,
+            iters: 0,
+            resid: 0.0,
+            rms: 0.0,
+            analytic: Vec::new(),
+            numeric: Vec::new(),
+        }
+    }
+}
+
+impl FlexureUI {
+    pub fn recompute(&mut self) {
+        let d = engine::flexure::d_from_te(self.e_pa, self.nu, self.te_m);
+        let a = engine::flexure::alpha(d, self.k_npm3);
+        self.alpha_km = a / 1000.0;
+        // build RHS and solve
+        let q = engine::flexure::line_load_rhs(self.n, self.dx_m, self.p_npm);
+        let sol = engine::flexure::solve_flexure_1d(&q, self.dx_m, d, self.k_npm3, 1e-8, 20_000);
+        self.iters = sol.iters;
+        self.resid = sol.resid;
+        // Build plot data
+        let i0 = self.n / 2;
+        // Analytic dense line over domain
+        let mut a_pts: Vec<[f64; 2]> = Vec::with_capacity(self.n * 2);
+        for i in 0..self.n {
+            let x = (i as f64 - i0 as f64) * self.dx_m;
+            let y = engine::flexure::w_line_analytic(x, self.p_npm, d, self.k_npm3);
+            a_pts.push([x / 1000.0, y]);
+        }
+        self.analytic = a_pts;
+        // Numeric sparse points
+        let stride = (self.n / 256).max(1);
+        let mut n_pts: Vec<[f64; 2]> = Vec::new();
+        for i in (0..self.n).step_by(stride) {
+            let x = (i as f64 - i0 as f64) * self.dx_m;
+            n_pts.push([x / 1000.0, sol.w[i]]);
+        }
+        self.numeric = n_pts;
+        // RMS over |x|<=4a
+        let xwin = 4.0 * a;
+        let imax = ((xwin / self.dx_m).floor() as isize).min(i0 as isize);
+        let mut sum2 = 0.0;
+        let mut sum2_ref = 0.0;
+        let mut count = 0.0;
+        for di in -(imax as isize)..=(imax as isize) {
+            let i = (i0 as isize + di) as usize;
+            let x = (di as f64) * self.dx_m;
+            let wa = engine::flexure::w_line_analytic(x, self.p_npm, d, self.k_npm3);
+            let wn = sol.w[i];
+            sum2 += (wn - wa) * (wn - wa);
+            sum2_ref += wa * wa;
+            count += 1.0;
+        }
+        let rms = (sum2 / count).sqrt();
+        let ref_rms = (sum2_ref / count).sqrt().max(1e-12);
+        self.rms = rms / ref_rms;
+    }
+
+    pub fn ui(&mut self, ui: &mut Ui) {
+        if !self.show {
+            return;
+        }
+        ui.label("Flexure (1D)");
+        let mut changed = false;
+        changed |= ui.add(Slider::new(&mut self.e_pa, 10e9..=200e9).text("E (Pa)")).changed();
+        changed |= ui.add(Slider::new(&mut self.nu, 0.15..=0.35).text("nu")).changed();
+        changed |= ui.add(Slider::new(&mut self.te_m, 5_000.0..=60_000.0).text("Te (m)")).changed();
+        changed |= ui
+            .add(Slider::new(&mut self.k_npm3, 1.0e8..=1.0e9).logarithmic(true).text("k (N/m^3)"))
+            .changed();
+        changed |= ui
+            .add(Slider::new(&mut self.p_npm, 1.0e10..=5.0e12).logarithmic(true).text("P (N/m)"))
+            .changed();
+        changed |= ui.add(Slider::new(&mut self.dx_m, 1000.0..=20_000.0).text("dx (m)")).changed();
+        changed |= ui.add(Slider::new(&mut self.n, 257..=4097).text("N")).changed();
+
+        if changed {
+            self.recompute();
+        }
+
+        ui.label(format!("alpha = {:.1} km", self.alpha_km));
+        ui.label(format!("CG iters = {}  resid = {:.2e}", self.iters, self.resid));
+        ui.label(format!("RMS (|x|<=4α) = {:.2}%", self.rms * 100.0));
+
+        Plot::new("flexure_plot")
+            .view_aspect(2.0)
+            .x_axis_label("x (km)")
+            .y_axis_label("w (m)")
+            .show(ui, |plot_ui| {
+                plot_ui.line(Line::new(PlotPoints::from(self.analytic.clone())).name("analytic"));
+                plot_ui.points(Points::new(PlotPoints::from(self.numeric.clone())).name("numeric"));
+            });
+    }
+}


### PR DESCRIPTION
…solver; tests; viewer plot (F)

# PR for {TASK_ID}: {TASK_TITLE}

## Summary
- Task card: {link or ID}
- Scope: {one-liner}

## Changes
- Files touched (only those allowed by the card):
  - …

## Acceptance Criteria Matrix
| Criterion | Evidence |
|---|---|
| C1: {quote from card} | {tests/screens, code refs} |
| C2: {…} | {…} |

## Validation
- Unit tests: `cargo test -p engine` → {pass/fail}
- Lints: `cargo clippy -- -D warnings` → {pass}
- Format: `cargo fmt -- --check` → {pass}
- Viewer smoke test: `cargo run -p viewer` (60 FPS idle) → {ok}

## Benchmarks (include numbers)
- Machine/GPU: {e.g., 13700K + RTX 4080}
- Grid: F=256 (cells≈), Step time: {ms}
- Grid: F=512, Step time: {ms}
- Notes: {any perf regressions/mitigations}

## Screenshots / Plots (if applicable)
- Plate overlay / boundaries / age–depth plot

## Docs
- Updated: README, docs pages, public API rustdoc

## Risk/Assumptions
- {any assumptions taken to resolve ambiguity}

## Checklist
- [ ] Matches card ID & title
- [ ] Only allowed files modified
- [ ] New/changed APIs documented
- [ ] Tests updated
- [ ] Benchmarks run & recorded
- [ ] CI green
- [ ] Determinism maintained