### PR TITLE
fix(T-090): wider target range, extra Δoffset, lockable bathy scale; …

### DIFF
--- a/aule/engine/src/isostasy.rs
+++ b/aule/engine/src/isostasy.rs
@@ -1,0 +1,96 @@
+//! Global sea-level constraint utilities (constant ocean volume via uniform offset).
+
+/// Compute ocean volume (m^3) and ocean area (m^2) from depths and cell areas.
+/// depth_m: positive down; only depths >= 0 contribute volume/area.
+pub fn ocean_volume_from_depth(depth_m: &[f32], area_m2: &[f32]) -> (f64, f64) {
+    assert_eq!(depth_m.len(), area_m2.len());
+    let mut vol = 0.0f64;
+    let mut area = 0.0f64;
+    for i in 0..depth_m.len() {
+        let d = depth_m[i] as f64;
+        let a = area_m2[i] as f64;
+        if d > 0.0 && a > 0.0 {
+            vol += d * a;
+            area += a;
+        }
+    }
+    (vol, area)
+}
+
+/// In-place add a uniform sea-level offset (meters). Positive increases depth (down).
+pub fn apply_sea_level_offset(depth_m: &mut [f32], offset_m: f64) {
+    let off = offset_m as f32;
+    for d in depth_m {
+        *d += off;
+    }
+}
+
+/// Solve for offset (m) so that ocean_volume(depth+offset) ~= target_volume_m3 via bisection.
+pub fn solve_offset_for_volume(
+    depth_m: &[f32],
+    area_m2: &[f32],
+    target_vol_m3: f64,
+    tol_volume_m3: f64,
+    max_iter: u32,
+) -> f64 {
+    #[inline]
+    fn vol_off(depth_m: &[f32], area_m2: &[f32], off: f64) -> f64 {
+        let mut v = 0.0f64;
+        for (d, a) in depth_m.iter().zip(area_m2.iter()) {
+            let dd = (*d as f64) + off;
+            if dd > 0.0 {
+                v += dd * (*a as f64);
+            }
+        }
+        v
+    }
+
+    // Initial bracket
+    let mut lo = -10_000.0_f64;
+    let mut hi = 10_000.0_f64;
+    let mut f_lo = vol_off(depth_m, area_m2, lo) - target_vol_m3;
+    let mut f_hi = vol_off(depth_m, area_m2, hi) - target_vol_m3;
+
+    // Enlarge bracket if needed
+    let mut expand = 0;
+    while f_lo > 0.0 && expand < 4 {
+        lo -= 10_000.0;
+        f_lo = vol_off(depth_m, area_m2, lo) - target_vol_m3;
+        expand += 1;
+    }
+    expand = 0;
+    while f_hi < 0.0 && expand < 4 {
+        hi += 10_000.0;
+        f_hi = vol_off(depth_m, area_m2, hi) - target_vol_m3;
+        expand += 1;
+    }
+
+    // Bisection
+    let mut off = 0.5 * (lo + hi);
+    for _ in 0..max_iter {
+        off = 0.5 * (lo + hi);
+        let f_mid = vol_off(depth_m, area_m2, off) - target_vol_m3;
+        if f_mid.abs() <= tol_volume_m3 || (hi - lo).abs() < 1e-6 {
+            return off;
+        }
+        if (f_mid > 0.0) == (f_lo > 0.0) {
+            lo = off;
+            f_lo = f_mid;
+        } else {
+            hi = off;
+            f_hi = f_mid;
+        }
+    }
+    off
+}
+
+fn volume_with_offset(depth_m: &[f32], area_m2: &[f32], off: f64) -> f64 {
+    let mut v = 0.0f64;
+    for i in 0..depth_m.len() {
+        let d = (depth_m[i] as f64) + off;
+        if d > 0.0 {
+            v += d * (area_m2[i] as f64);
+        }
+    }
+    v
+}

--- a/aule/engine/src/lib.rs
+++ b/aule/engine/src/lib.rs
@@ -19,6 +19,8 @@ pub mod geo;
 pub mod gpu;
 /// Geodesic grid module.
 pub mod grid;
+/// Global sea-level (isostasy MVP) utilities.
+pub mod isostasy;
 /// Plates seeding and velocities.
 pub mod plates;
 /// Ridge births and fringe assignment (CPU pass).

--- a/aule/engine/tests/isostasy.rs
+++ b/aule/engine/tests/isostasy.rs
@@ -1,0 +1,59 @@
+use engine::isostasy;
+
+#[test]
+fn volume_monotonic_in_offset() {
+    let depth = vec![0.0f32, 1000.0, 2000.0, 0.0, 3000.0];
+    let area = vec![1.0f32; depth.len()];
+    let v1 = isostasy::solve_offset_for_volume(&depth, &area, 2_000.0, 1e-9, 128);
+    let v2 = isostasy::solve_offset_for_volume(&depth, &area, 3_000.0, 1e-9, 128);
+    assert!(v2 > v1);
+}
+
+#[test]
+fn solver_hits_target_within_tol() {
+    // Synthetic: depths 0..999, area=2.0 each
+    let n = 1000usize;
+    let mut depth = vec![0.0f32; n];
+    let area = vec![2.0f32; n];
+    for i in 0..n {
+        depth[i] = (i as f32) * 1.0;
+    }
+    let (v0, _a0) = isostasy::ocean_volume_from_depth(&depth, &area);
+    // Target: add 100 m average depth → additional volume = 100 * sum(area)
+    let sum_area: f64 = area.iter().map(|a| *a as f64).sum();
+    let target = v0 + 100.0 * sum_area;
+    let off = isostasy::solve_offset_for_volume(&depth, &area, target, 1e-6 * target, 128);
+    let after = volume_with_offset_ref(&depth, &area, off);
+    let err = (after - target).abs();
+    assert!(err <= 1e-6 * target, "err={} target={}", err, target);
+}
+
+#[test]
+fn idempotence_apply_offset() {
+    let mut depth = vec![100.0f32, 0.0, 50.0];
+    isostasy::apply_sea_level_offset(&mut depth, 20.0);
+    let once = depth.clone();
+    isostasy::apply_sea_level_offset(&mut depth, 0.0);
+    assert_eq!(depth, once);
+}
+
+#[test]
+fn determinism_same_inputs_same_offset() {
+    let depth = vec![0.0f32, 1000.0, 2000.0, 100.0];
+    let area = vec![1.0f32, 2.0, 3.0, 4.0];
+    let target = 10_000.0f64;
+    let a = isostasy::solve_offset_for_volume(&depth, &area, target, 1e-9, 128);
+    let b = isostasy::solve_offset_for_volume(&depth, &area, target, 1e-9, 128);
+    assert_eq!(a, b);
+}
+
+fn volume_with_offset_ref(depth: &[f32], area: &[f32], off: f64) -> f64 {
+    let mut v = 0.0f64;
+    for i in 0..depth.len() {
+        let d = (depth[i] as f64) + off;
+        if d > 0.0 {
+            v += d * (area[i] as f64);
+        }
+    }
+    v
+}


### PR DESCRIPTION
…robust isostasy bisection; logs; persist slider

# PR for {TASK_ID}: {TASK_TITLE}

## Summary
- Task card: {link or ID}
- Scope: {one-liner}

## Changes
- Files touched (only those allowed by the card):
  - …

## Acceptance Criteria Matrix
| Criterion | Evidence |
|---|---|
| C1: {quote from card} | {tests/screens, code refs} |
| C2: {…} | {…} |

## Validation
- Unit tests: `cargo test -p engine` → {pass/fail}
- Lints: `cargo clippy -- -D warnings` → {pass}
- Format: `cargo fmt -- --check` → {pass}
- Viewer smoke test: `cargo run -p viewer` (60 FPS idle) → {ok}

## Benchmarks (include numbers)
- Machine/GPU: {e.g., 13700K + RTX 4080}
- Grid: F=256 (cells≈), Step time: {ms}
- Grid: F=512, Step time: {ms}
- Notes: {any perf regressions/mitigations}

## Screenshots / Plots (if applicable)
- Plate overlay / boundaries / age–depth plot

## Docs
- Updated: README, docs pages, public API rustdoc

## Risk/Assumptions
- {any assumptions taken to resolve ambiguity}

## Checklist
- [ ] Matches card ID & title
- [ ] Only allowed files modified
- [ ] New/changed APIs documented
- [ ] Tests updated
- [ ] Benchmarks run & recorded
- [ ] CI green
- [ ] Determinism maintained