### PR TITLE
feat(T-051): viewer HUD+overlay for continents; cached meshes; recomp…

### DIFF
--- a/aule/engine/src/continent.rs
+++ b/aule/engine/src/continent.rs
@@ -1,0 +1,168 @@
+//! Synthetic continental mask (few large cratons) built procedurally on the unit sphere.
+//! Deterministic given seed; uses smooth-union of Gaussian caps with a flat plateau.
+
+use crate::grid::Grid;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+/// Parameters controlling continent generation and application.
+#[derive(Clone, Copy)]
+pub struct ContinentParams {
+    /// RNG seed (deterministic)
+    pub seed: u64,
+    /// Number of continents (caps)
+    pub n_continents: u32,
+    /// Plateau mean radius (km)
+    pub mean_radius_km: f64,
+    /// Gaussian falloff sigma (km)
+    pub falloff_km: f64,
+    /// Plateau uplift (negative is up/shallower)
+    pub plateau_uplift_m: f32,
+    /// Optional target land fraction (0..1); None → manual amplitude
+    pub target_land_fraction: Option<f64>,
+}
+
+/// Outputs for continents
+pub struct ContinentField {
+    /// Unitless 0..1 template per cell; will be scaled by amplitude
+    pub uplift_template_m: Vec<f32>,
+    /// Applied uplift in meters (negative up) per cell
+    pub uplift_applied_m: Vec<f32>,
+    /// Land mask after application (depth ≤ 0)
+    pub mask_land: Vec<bool>,
+    /// Area-weighted fraction of land
+    pub land_fraction: f64,
+}
+
+/// Build continent template (unitless 0..1) from smooth union of caps.
+pub fn build_continents(grid: &Grid, p: ContinentParams) -> ContinentField {
+    let mut template: Vec<f32> = vec![0.0; grid.cells];
+
+    // Deterministic RNG (namespaced)
+    let ns: u64 = 0x636f6e74696e65; // "contine"
+    let mut rng = StdRng::seed_from_u64(p.seed ^ ns);
+
+    // Generate cap centers uniformly on sphere
+    let mut centers: Vec<[f64; 3]> = Vec::with_capacity(p.n_continents as usize);
+    for _ in 0..p.n_continents {
+        // Uniform on sphere via z in [-1,1], phi in [0,2pi)
+        let z: f64 = rng.gen_range(-1.0..=1.0);
+        let phi: f64 = rng.gen_range(0.0..(2.0 * std::f64::consts::PI));
+        let rxy = (1.0 - z * z).sqrt();
+        centers.push([rxy * phi.cos(), rxy * phi.sin(), z]);
+    }
+
+    // Parameters in radians
+    const R_EARTH_M: f64 = 6_371_000.0;
+    let sigma_rad = (p.falloff_km * 1000.0) / R_EARTH_M;
+    let r0_rad = (p.mean_radius_km * 1000.0) / R_EARTH_M;
+
+    for (i, r) in grid.pos_xyz.iter().enumerate() {
+        let rhat = [r[0] as f64, r[1] as f64, r[2] as f64];
+        let mut inv_prod = 1.0f64; // ∏(1 - t_k)
+        for c in &centers {
+            let dot = rhat[0] * c[0] + rhat[1] * c[1] + rhat[2] * c[2];
+            let dot = dot.clamp(-1.0, 1.0);
+            let theta = dot.acos();
+            let tk = if theta <= r0_rad {
+                1.0
+            } else {
+                let x = theta / sigma_rad;
+                (-0.5 * x * x).exp()
+            };
+            inv_prod *= 1.0 - tk;
+        }
+        let t = 1.0 - inv_prod;
+        template[i] = t as f32;
+    }
+
+    ContinentField {
+        uplift_template_m: template,
+        uplift_applied_m: vec![0.0; grid.cells],
+        mask_land: vec![false; grid.cells],
+        land_fraction: 0.0,
+    }
+}
+
+/// Solve amplitude (meters, ≥0) to reach target land fraction via bisection.
+pub fn solve_amplitude_for_target_land_fraction(
+    depth_before_m: &[f32],
+    uplift_template_m: &[f32],
+    area_m2: &[f32],
+    target_frac: f64,
+    tol: f64,
+    max_iter: u32,
+) -> f32 {
+    let total_area: f64 = area_m2.iter().map(|&a| a as f64).sum();
+    if total_area <= 0.0 {
+        return 0.0;
+    }
+    let mut lo = 0.0f64;
+    let mut hi = 10_000.0f64; // 10 km uplift
+
+    let f = |amp: f64| -> f64 {
+        let mut land_area = 0.0f64;
+        for i in 0..depth_before_m.len() {
+            let d = depth_before_m[i] as f64 - amp * (uplift_template_m[i] as f64);
+            if d <= 0.0 {
+                land_area += area_m2[i] as f64;
+            }
+        }
+        (land_area / total_area) - target_frac
+    };
+
+    // Ensure bracket contains root
+    let mut f_lo = f(lo);
+    let mut _f_hi = f(hi);
+    let mut expand = 0;
+    while f_lo > 0.0 && expand < 4 {
+        hi *= 2.0;
+        _f_hi = f(hi);
+        expand += 1;
+    }
+    expand = 0;
+    while _f_hi < 0.0 && expand < 4 {
+        hi *= 2.0;
+        _f_hi = f(hi);
+        expand += 1;
+    }
+
+    let mut amp = 0.5 * (lo + hi);
+    for _ in 0..max_iter {
+        amp = 0.5 * (lo + hi);
+        let fm = f(amp);
+        if fm.abs() <= tol || (hi - lo).abs() < 1e-6 {
+            return amp as f32;
+        }
+        if (fm > 0.0) == (f_lo > 0.0) {
+            lo = amp;
+            f_lo = fm;
+        } else {
+            hi = amp;
+        }
+    }
+    amp as f32
+}
+
+/// Apply continents uplift: depth += -(amp * template). Returns (mask_land, land_fraction).
+pub fn apply_continents(
+    depth_m: &mut [f32],
+    uplift_template_m: &[f32],
+    amp_m: f32,
+    area_m2: &[f32],
+) -> (Vec<bool>, f64) {
+    for i in 0..depth_m.len() {
+        depth_m[i] += -(amp_m * uplift_template_m[i]);
+    }
+    let total_area: f64 = area_m2.iter().map(|&a| a as f64).sum();
+    let mut land_area = 0.0f64;
+    let mut mask = vec![false; depth_m.len()];
+    for i in 0..depth_m.len() {
+        if depth_m[i] <= 0.0 {
+            land_area += area_m2[i] as f64;
+            mask[i] = true;
+        }
+    }
+    let frac = if total_area > 0.0 { land_area / total_area } else { 0.0 };
+    (mask, frac)
+}

--- a/aule/engine/src/isostasy.rs
+++ b/aule/engine/src/isostasy.rs
@@ -49,7 +49,7 @@ pub fn solve_offset_for_volume(
     let mut lo = -10_000.0_f64;
     let mut hi = 10_000.0_f64;
     let mut f_lo = vol_off(depth_m, area_m2, lo) - target_vol_m3;
-    let mut f_hi = vol_off(depth_m, area_m2, hi) - target_vol_m3;
+    let mut _f_hi = vol_off(depth_m, area_m2, hi) - target_vol_m3;
 
     // Enlarge bracket if needed
     let mut expand = 0;
@@ -59,9 +59,9 @@ pub fn solve_offset_for_volume(
         expand += 1;
     }
     expand = 0;
-    while f_hi < 0.0 && expand < 4 {
+    while _f_hi < 0.0 && expand < 4 {
         hi += 10_000.0;
-        f_hi = vol_off(depth_m, area_m2, hi) - target_vol_m3;
+        _f_hi = vol_off(depth_m, area_m2, hi) - target_vol_m3;
         expand += 1;
     }
 
@@ -78,19 +78,7 @@ pub fn solve_offset_for_volume(
             f_lo = f_mid;
         } else {
             hi = off;
-            f_hi = f_mid;
         }
     }
     off
-}
-
-fn volume_with_offset(depth_m: &[f32], area_m2: &[f32], off: f64) -> f64 {
-    let mut v = 0.0f64;
-    for i in 0..depth_m.len() {
-        let d = (depth_m[i] as f64) + off;
-        if d > 0.0 {
-            v += d * (area_m2[i] as f64);
-        }
-    }
-    v
 }

--- a/aule/engine/src/lib.rs
+++ b/aule/engine/src/lib.rs
@@ -7,6 +7,8 @@
 pub mod age;
 /// Plate boundary classification.
 pub mod boundaries;
+/// Synthetic continental mask generator and applier.
+pub mod continent;
 /// Field and tiling views.
 pub mod fields;
 /// 1D elastic plate flexure (CPU reference; analytic + CG solver).

--- a/aule/engine/tests/continent.rs
+++ b/aule/engine/tests/continent.rs
@@ -1,0 +1,50 @@
+use engine::{continent, grid::Grid};
+
+#[test]
+fn determinism_template() {
+    let g = Grid::new(16);
+    let p = continent::ContinentParams {
+        seed: 42,
+        n_continents: 3,
+        mean_radius_km: 2200.0,
+        falloff_km: 600.0,
+        plateau_uplift_m: -2500.0,
+        target_land_fraction: None,
+    };
+    let c0 = continent::build_continents(&g, p);
+    let c1 = continent::build_continents(&g, p);
+    assert_eq!(c0.uplift_template_m, c1.uplift_template_m);
+}
+
+#[test]
+fn amplitude_targets_land_fraction() {
+    let g = Grid::new(16);
+    // synthetic depths: radial with some spread
+    let mut depth = vec![3000.0f32; g.cells];
+    // areas in m^2 (unit-sphere areas scaled by Earth sphere)
+    const R: f64 = 6_371_000.0;
+    let scale = 4.0 * std::f64::consts::PI * R * R;
+    let area_m2: Vec<f32> = g.area.iter().map(|&a| (a as f64 * scale) as f32).collect();
+    let p = continent::ContinentParams {
+        seed: 7,
+        n_continents: 3,
+        mean_radius_km: 2200.0,
+        falloff_km: 600.0,
+        plateau_uplift_m: -2500.0,
+        target_land_fraction: None,
+    };
+    let c = continent::build_continents(&g, p);
+    // With these cap sizes the reachable union is ~8–10%
+    let target = 0.08;
+    let amp = continent::solve_amplitude_for_target_land_fraction(
+        &depth,
+        &c.uplift_template_m,
+        &area_m2,
+        target,
+        1e-3,
+        128,
+    );
+    let (_mask, frac) =
+        continent::apply_continents(&mut depth, &c.uplift_template_m, amp, &area_m2);
+    assert!((frac - target).abs() <= 0.02, "frac={} target={}", frac, target);
+}

--- a/aule/engine/tests/isostasy.rs
+++ b/aule/engine/tests/isostasy.rs
@@ -15,8 +15,8 @@ fn solver_hits_target_within_tol() {
     let n = 1000usize;
     let mut depth = vec![0.0f32; n];
     let area = vec![2.0f32; n];
-    for i in 0..n {
-        depth[i] = (i as f32) * 1.0;
+    for (i, d) in depth.iter_mut().enumerate().take(n) {
+        *d = (i as f32) * 1.0;
     }
     let (v0, _a0) = isostasy::ocean_volume_from_depth(&depth, &area);
     // Target: add 100 m average depth → additional volume = 100 * sum(area)

--- a/aule/viewer/src/overlay.rs
+++ b/aule/viewer/src/overlay.rs
@@ -3,6 +3,16 @@ use egui::{
     Color32, Pos2, Rect, Stroke, Vec2,
 };
 
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct ContKey {
+    pub seed: u64,
+    pub n: u32,
+    pub radius_km: u32,
+    pub falloff_km: u32,
+    pub f: u32,
+}
+
+#[allow(dead_code)]
 pub struct OverlayState {
     pub show_hud: bool,
     pub show_plates: bool,
@@ -74,6 +84,23 @@ pub struct OverlayState {
     pub trans_max_points: u32,
     pub trans_pull_count: u32,
     pub trans_rest_count: u32,
+
+    // Continents overlay/state
+    pub show_continents: bool,
+    pub cont_seed: u64,
+    pub cont_n: u32,
+    pub cont_radius_km: f64,
+    pub cont_falloff_km: f64,
+    pub cont_auto_amp: bool,
+    pub cont_target_land_frac: f32,
+    pub cont_manual_amp_m: f32,
+    pub cont_max_points: usize,
+    pub mesh_continents: Option<Mesh>,
+    pub mesh_coastline: Option<Mesh>,
+    pub cont_land_frac: f64,
+    pub cont_amp_applied_m: f32,
+    pub cont_key: Option<ContKey>,
+    pub cont_template: Option<Vec<f32>>,
 }
 
 impl Default for OverlayState {
@@ -137,6 +164,22 @@ impl Default for OverlayState {
             trans_max_points: 10_000,
             trans_pull_count: 0,
             trans_rest_count: 0,
+
+            show_continents: false,
+            cont_seed: 1_234_567,
+            cont_n: 3,
+            cont_radius_km: 2200.0,
+            cont_falloff_km: 600.0,
+            cont_auto_amp: true,
+            cont_target_land_frac: 0.29,
+            cont_manual_amp_m: 2500.0,
+            cont_max_points: 20_000,
+            mesh_continents: None,
+            mesh_coastline: None,
+            cont_land_frac: 0.0,
+            cont_amp_applied_m: 0.0,
+            cont_key: None,
+            cont_template: None,
         }
     }
 }
@@ -462,8 +505,8 @@ impl OverlayState {
     pub fn rebuild_bathy_shapes(&mut self, rect: Rect, grid: &engine::grid::Grid, depth_m: &[f32]) {
         let mut shapes = Vec::with_capacity(grid.latlon.len());
         let (dmin, dmax) = self.depth_minmax;
-        for i in 0..grid.latlon.len() {
-            let p = project_equirect(grid.latlon[i][0], grid.latlon[i][1], rect);
+        for (i, &ll) in grid.latlon.iter().enumerate() {
+            let p = project_equirect(ll[0], ll[1], rect);
             let col = blue_ramp(depth_m[i], dmin, dmax);
             shapes.push(Shape::circle_filled(p, 1.2, col));
         }
@@ -490,6 +533,52 @@ impl OverlayState {
         }
         shapes.extend(coast);
         self.bathy_cache = Some(shapes);
+    }
+
+    /// Build continent land mask and coastline meshes
+    pub fn rebuild_continent_meshes(
+        &mut self,
+        rect: Rect,
+        grid: &engine::grid::Grid,
+        depth_m: &[f32],
+        mask_land: &[bool],
+        cap_total: usize,
+    ) -> (Mesh, Mesh) {
+        // Land point cloud
+        let mut land_indices: Vec<usize> = Vec::new();
+        for (i, &is_land) in mask_land.iter().enumerate() {
+            if is_land {
+                land_indices.push(i);
+            }
+        }
+        let mut mesh_land = Mesh::default();
+        let mut mesh_coast = Mesh::default();
+        let total = land_indices.len().max(1);
+        let stride = (total / cap_total.max(1)).max(1);
+        let col_land = Color32::from_rgba_unmultiplied(120, 120, 120, 160);
+        let r = 1.2;
+        for &i in land_indices.iter().step_by(stride) {
+            let p = project_equirect(grid.latlon[i][0], grid.latlon[i][1], rect);
+            Self::mesh_add_dot(&mut mesh_land, p, r, col_land);
+        }
+        // Coastline: neighbors crossing 0 m
+        for i in 0..grid.latlon.len() {
+            let di = depth_m[i];
+            for &n in &grid.n1[i] {
+                let j = n as usize;
+                let dj = depth_m[j];
+                if (di > 0.0 && dj <= 0.0) || (di <= 0.0 && dj > 0.0) {
+                    let pu = project_equirect(grid.latlon[i][0], grid.latlon[i][1], rect);
+                    let pv = project_equirect(grid.latlon[j][0], grid.latlon[j][1], rect);
+                    let center = Pos2::new((pu.x + pv.x) * 0.5, (pu.y + pv.y) * 0.5);
+                    let dir = (pv - pu).normalized();
+                    let _orth = Vec2::new(-dir.y, dir.x);
+                    // Approximate thin segment by a small dot at the midpoint for performance
+                    Self::mesh_add_dot(&mut mesh_coast, center, 0.8, Color32::BLACK);
+                }
+            }
+        }
+        (mesh_land, mesh_coast)
     }
 
     pub fn age_shapes(&self) -> &[Shape] {


### PR DESCRIPTION
…ute before sea level

# PR for {TASK_ID}: {TASK_TITLE}

## Summary
- Task card: {link or ID}
- Scope: {one-liner}

## Changes
- Files touched (only those allowed by the card):
  - …

## Acceptance Criteria Matrix
| Criterion | Evidence |
|---|---|
| C1: {quote from card} | {tests/screens, code refs} |
| C2: {…} | {…} |

## Validation
- Unit tests: `cargo test -p engine` → {pass/fail}
- Lints: `cargo clippy -- -D warnings` → {pass}
- Format: `cargo fmt -- --check` → {pass}
- Viewer smoke test: `cargo run -p viewer` (60 FPS idle) → {ok}

## Benchmarks (include numbers)
- Machine/GPU: {e.g., 13700K + RTX 4080}
- Grid: F=256 (cells≈), Step time: {ms}
- Grid: F=512, Step time: {ms}
- Notes: {any perf regressions/mitigations}

## Screenshots / Plots (if applicable)
- Plate overlay / boundaries / age–depth plot

## Docs
- Updated: README, docs pages, public API rustdoc

## Risk/Assumptions
- {any assumptions taken to resolve ambiguity}

## Checklist
- [ ] Matches card ID & title
- [ ] Only allowed files modified
- [ ] New/changed APIs documented
- [ ] Tests updated
- [ ] Benchmarks run & recorded
- [ ] CI green
- [ ] Determinism maintained