### PR TITLE
fix(T-082): robust overlay invalidation; viewport-change tracking; st…

### DIFF
--- a/aule/viewer/src/overlay.rs
+++ b/aule/viewer/src/overlay.rs
@@ -116,6 +116,17 @@ pub struct OverlayState {
     pub max_points_flex: usize, // overlay cap
     pub last_residual: f32,     // r_out / max(1,r_in)
     pub flex_mesh: Option<Mesh>,
+    pub subtract_mean_load: bool,
+    pub flex_cycles: u32,
+    pub flex_gain: f32,
+    pub apply_gain_to_depth: bool,
+    pub flex_overlay_count: usize,
+
+    // Viewport tracking and debounce
+    pub last_map_rect_px: [i32; 4], // x,y,w,h rounded
+    pub viewport_epoch: u64,
+    pub world_dirty: bool,
+    pub flex_dirty: bool,
 }
 
 impl Default for OverlayState {
@@ -209,7 +220,37 @@ impl Default for OverlayState {
             max_points_flex: 10_000,
             last_residual: 0.0,
             flex_mesh: None,
+            subtract_mean_load: true,
+            flex_cycles: 1,
+            flex_gain: 1.0,
+            apply_gain_to_depth: false,
+            flex_overlay_count: 0,
+
+            last_map_rect_px: [0, 0, 0, 0],
+            viewport_epoch: 0,
+            world_dirty: false,
+            flex_dirty: false,
         }
+    }
+}
+
+impl OverlayState {
+    /// Invalidate all cached overlay meshes so they will rebuild next frame.
+    pub fn invalidate_all_meshes(&mut self) {
+        self.plates_cache = None;
+        self.vel_cache = None;
+        self.bounds_cache = None;
+        self.age_cache = None;
+        self.bathy_cache = None;
+        self.subd_trench = None;
+        self.subd_arc = None;
+        self.subd_backarc = None;
+        self.trans_pull = None;
+        self.trans_rest = None;
+        self.mesh_continents = None;
+        self.mesh_coastline = None;
+        self.flex_mesh = None;
+        self.flex_overlay_count = 0;
     }
 }
 


### PR DESCRIPTION
Added viewport tracking, strict gating, and recompute debounce:
OverlayState: subtract_mean_load, flex_cycles, flex_gain, apply_gain_to_depth, flex_overlay_count, last_map_rect_px, viewport_epoch, world_dirty, flex_dirty.
OverlayState::invalidate_all_meshes() clears all mesh caches.
In main.rs, track available_rect and bump viewport_epoch on change; invalidate meshes and request repaint.
Strict draw gating: draw only if show flag is true; clear meshes immediately when toggled off.
Debounce flags world_dirty and flex_dirty set via UI; recompute blocks use those flags; flex overlay rebuilt only when needed.
HUD shows overlay counts; residual label reads from ov.last_residual.
Flexure tweaks maintained:
Subtract area-weighted mean load when enabled.
“V-cycles” slider and overlay gain; gain only affects overlay unless debug toggle is set.
CI: fmt, clippy -D warnings, and tests all pass locally.
Push:
Local tree is clean and previous commits are pushed to feat/T-082-flexure-coupling. If you’re on a different branch locally, run:
git push --set-upstream origin <your-branch-name>
Changes:
aule/viewer/src/overlay.rs: state fields and invalidate_all_meshes.
aule/viewer/src/main.rs: viewport monitoring, gating, debounce, counts, logs, and updated recompute flow.