### PR TITLE
fix(T-410): wire continents & flexure into stepper; edge-triggered sn…

### DIFF
--- a/aule/engine/src/world.rs
+++ b/aule/engine/src/world.rs
@@ -315,7 +315,9 @@ pub fn step_once(world: &mut World, sp: &StepParams) -> StepStats {
     // Stats for log line
     let total_area: f64 = world.area_m2.iter().map(|&a| a as f64).sum();
     let mut weighted_c: f64 = 0.0;
-    for i in 0..n { weighted_c += (world.c[i] as f64) * (world.area_m2[i] as f64); }
+    for i in 0..n {
+        weighted_c += (world.c[i] as f64) * (world.area_m2[i] as f64);
+    }
     let c_bar = if total_area > 0.0 { weighted_c / total_area } else { 0.0 };
 
     // Advect diagnostics (rough backtrace distance)


### PR DESCRIPTION
…apshots; logs; antimeridian-safe overlay midpoints (T-120)

# PR for {TASK_ID}: {TASK_TITLE}

## Summary
- Task card: {link or ID}
- Scope: {one-liner}

## Changes
- Files touched (only those allowed by the card):
  - …

## Acceptance Criteria Matrix
| Criterion | Evidence |
|---|---|
| C1: {quote from card} | {tests/screens, code refs} |
| C2: {…} | {…} |

## Validation
- Unit tests: `cargo test -p engine` → {pass/fail}
- Lints: `cargo clippy -- -D warnings` → {pass}
- Format: `cargo fmt -- --check` → {pass}
- Viewer smoke test: `cargo run -p viewer` (60 FPS idle) → {ok}

## Benchmarks (include numbers)
- Machine/GPU: {e.g., 13700K + RTX 4080}
- Grid: F=256 (cells≈), Step time: {ms}
- Grid: F=512, Step time: {ms}
- Notes: {any perf regressions/mitigations}

## Screenshots / Plots (if applicable)
- Plate overlay / boundaries / age–depth plot

## Docs
- Updated: README, docs pages, public API rustdoc

## Risk/Assumptions
- {any assumptions taken to resolve ambiguity}

## Checklist
- [ ] Matches card ID & title
- [ ] Only allowed files modified
- [ ] New/changed APIs documented
- [ ] Tests updated
- [ ] Benchmarks run & recorded
- [ ] CI green
- [ ] Determinism maintained