### PR TITLE
feat(T-401): rigid plate kinematics, plate-id advection; viewer kinem…

### DIFF
--- a/aule/engine/src/lib.rs
+++ b/aule/engine/src/lib.rs
@@ -33,6 +33,8 @@ pub mod isostasy;
 pub mod plates;
 /// Ridge births and fringe assignment (CPU pass).
 pub mod ridge;
+/// Semi-Lagrangian advection helpers (CPU, deterministic).
+pub mod sl_advect;
 /// Snapshot IO utilities (CSV/binary)
 pub mod snapshots;
 /// World stepper.

--- a/aule/engine/src/sl_advect.rs
+++ b/aule/engine/src/sl_advect.rs
@@ -1,0 +1,66 @@
+//! Semi-Lagrangian backtrace helpers for categorical and scalar fields (MVP).
+
+use crate::grid::Grid;
+
+/// Backtrace from unit vector `r` by `dt_myr` along velocity `v_m_per_yr` (3D) on the sphere.
+/// Returns a unit vector approximating the source position.
+pub fn backtrace_r(r: [f32; 3], v_m_per_yr: [f32; 3], dt_myr: f64) -> [f32; 3] {
+    // Convert displacement to an angular small rotation about axis perpendicular to r and v
+    // For MVP, use simple Euler: r_src ≈ normalize(r - (dt * v / R))
+    const R_EARTH_M: f64 = 6_371_000.0;
+    let dt_yr = (dt_myr * 1.0e6) as f32;
+    let dr = [
+        -v_m_per_yr[0] * dt_yr / (R_EARTH_M as f32),
+        -v_m_per_yr[1] * dt_yr / (R_EARTH_M as f32),
+        -v_m_per_yr[2] * dt_yr / (R_EARTH_M as f32),
+    ];
+    let rr = [r[0] + dr[0], r[1] + dr[1], r[2] + dr[2]];
+    let n = (rr[0] * rr[0] + rr[1] * rr[1] + rr[2] * rr[2]).sqrt();
+    if n > 0.0 {
+        [rr[0] / n, rr[1] / n, rr[2] / n]
+    } else {
+        r
+    }
+}
+
+/// Find nearest neighbor cell to unit vector `r_src` using 1-ring + 2-ring of the provided `start_i`.
+fn nearest_idx_local(grid: &Grid, start_i: usize, r_src: [f32; 3]) -> usize {
+    let mut best_i = start_i;
+    let mut best_d2 = f32::INFINITY;
+    let check = |i: usize, best_i: &mut usize, best_d2: &mut f32| {
+        let dx = grid.pos_xyz[i][0] - r_src[0];
+        let dy = grid.pos_xyz[i][1] - r_src[1];
+        let dz = grid.pos_xyz[i][2] - r_src[2];
+        let d2 = dx * dx + dy * dy + dz * dz;
+        if d2 < *best_d2 || (d2 - *best_d2).abs() <= f32::EPSILON && i < *best_i {
+            *best_d2 = d2;
+            *best_i = i;
+        }
+    };
+    check(start_i, &mut best_i, &mut best_d2);
+    for &n in &grid.n1[start_i] {
+        check(n as usize, &mut best_i, &mut best_d2);
+    }
+    for &n in &grid.n2[start_i] {
+        check(n as usize, &mut best_i, &mut best_d2);
+    }
+    best_i
+}
+
+/// Advect categorical `plate_id` via nearest-neighbor semi-Lagrangian backtrace.
+pub fn advect_plate_id(
+    grid: &Grid,
+    vel_m_per_yr: &[[f32; 3]],
+    dt_myr: f64,
+    plate_id_in: &[u16],
+    plate_id_out: &mut [u16],
+) {
+    let n = grid.cells.min(vel_m_per_yr.len()).min(plate_id_in.len()).min(plate_id_out.len());
+    for i in 0..n {
+        let r = grid.pos_xyz[i];
+        let v = vel_m_per_yr[i];
+        let r_src = backtrace_r(r, v, dt_myr);
+        let j = nearest_idx_local(grid, i, r_src);
+        plate_id_out[i] = plate_id_in[j];
+    }
+}

--- a/aule/engine/tests/plates_kinematics.rs
+++ b/aule/engine/tests/plates_kinematics.rs
@@ -1,0 +1,15 @@
+use engine as crate_engine;
+
+#[test]
+fn rodrigues_roundtrip_small_error() {
+    let axis = [0.0f32, 0.0, 1.0];
+    let r = [1.0f32, 0.0, 0.0];
+    let theta = 0.25f32;
+    let r1 = crate_engine::plates::rotate_point(axis, theta, r);
+    let r2 = crate_engine::plates::rotate_point(axis, -theta, r1);
+    let err = ((r2[0] as f64 - r[0] as f64).powi(2)
+        + (r2[1] as f64 - r[1] as f64).powi(2)
+        + (r2[2] as f64 - r[2] as f64).powi(2))
+    .sqrt();
+    assert!(err < 1e-6, "roundtrip err = {}", err);
+}

--- a/aule/viewer/src/overlay.rs
+++ b/aule/viewer/src/overlay.rs
@@ -2,6 +2,7 @@ use egui::{
     epaint::{Mesh, Shape, Vertex, WHITE_UV},
     Color32, Pos2, Rect, Stroke, Vec2,
 };
+use std::collections::HashMap;
 
 const R_EARTH_M: f32 = 6_371_000.0;
 
@@ -20,6 +21,10 @@ pub struct OverlayState {
     pub show_plates: bool,
     pub show_vel: bool,
     pub show_bounds: bool,
+    // Kinematics (rigid plates)
+    pub kin_enable: bool,
+    pub kin_trail_steps: u32,
+    pub kin_trails: Option<HashMap<(u32, u32), Vec<Pos2>>>,
 
     // HUD parameters
     pub vel_scale_px_per_cm_yr: f32, // px per (cm/yr)
@@ -170,6 +175,9 @@ impl Default for OverlayState {
             show_plates: false,
             show_vel: false,
             show_bounds: false,
+            kin_enable: true,
+            kin_trail_steps: 0,
+            kin_trails: None,
             vel_scale_px_per_cm_yr: vel_scale_default,
             max_arrows_slider: max_default,
             max_bounds_slider: max_default,
@@ -335,7 +343,7 @@ pub fn project_equirect(lat: f32, lon: f32, rect: Rect) -> Pos2 {
 /// If the segment crosses the antimeridian (|dx| > 0.5*width), virtually unwrap one
 /// endpoint so the midpoint is computed along the shorter wrapped arc, then wrap the
 /// result back to the viewport.
-fn wrap_midpoint_equirect(pu: Pos2, pv: Pos2, rect: Rect) -> Pos2 {
+pub fn wrap_midpoint_equirect(pu: Pos2, pv: Pos2, rect: Rect) -> Pos2 {
     let w = rect.width();
     let x1 = pu.x;
     let mut x2 = pv.x;


### PR DESCRIPTION
…atics HUD and drift trails

# PR for {TASK_ID}: {TASK_TITLE}

## Summary
- Task card: {link or ID}
- Scope: {one-liner}

## Changes
- Files touched (only those allowed by the card):
  - …

## Acceptance Criteria Matrix
| Criterion | Evidence |
|---|---|
| C1: {quote from card} | {tests/screens, code refs} |
| C2: {…} | {…} |

## Validation
- Unit tests: `cargo test -p engine` → {pass/fail}
- Lints: `cargo clippy -- -D warnings` → {pass}
- Format: `cargo fmt -- --check` → {pass}
- Viewer smoke test: `cargo run -p viewer` (60 FPS idle) → {ok}

## Benchmarks (include numbers)
- Machine/GPU: {e.g., 13700K + RTX 4080}
- Grid: F=256 (cells≈), Step time: {ms}
- Grid: F=512, Step time: {ms}
- Notes: {any perf regressions/mitigations}

## Screenshots / Plots (if applicable)
- Plate overlay / boundaries / age–depth plot

## Docs
- Updated: README, docs pages, public API rustdoc

## Risk/Assumptions
- {any assumptions taken to resolve ambiguity}

## Checklist
- [ ] Matches card ID & title
- [ ] Only allowed files modified
- [ ] New/changed APIs documented
- [ ] Tests updated
- [ ] Benchmarks run & recorded
- [ ] CI green
- [ ] Determinism maintained